### PR TITLE
Adicionar depêndencias faltantes para testes do frontend

### DIFF
--- a/unbrake-frontend/package.json
+++ b/unbrake-frontend/package.json
@@ -4,6 +4,7 @@
   "private": false,
   "dependencies": {
     "@material-ui/core": "^3.9.2",
+    "prop-types": "^15.7.2",
     "react": "^16.8.5",
     "react-dom": "^16.8.5",
     "react-redux": "^6.0.1",
@@ -31,17 +32,21 @@
     "not op_mini all"
   ],
   "devDependencies": {
-    "eslint-plugin-jest": "^22.4.1",
+    "enzyme": "^3.9.0",
+    "enzyme-adapter-react-16": "^1.11.2",
+    "enzyme-to-json": "^3.3.5",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-import": "^2.16.0",
+    "eslint-plugin-jest": "^22.4.1",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.12.4",
     "husky": "^1.3.1",
     "lint-staged": "^8.1.5",
     "prettier": "^1.16.4",
-    "pretty-quick": "^1.10.0"
+    "pretty-quick": "^1.10.0",
+    "redux-mock-store": "^1.5.3"
   },
   "husky": {
     "hooks": {
@@ -57,4 +62,3 @@
     ]
   }
 }
-


### PR DESCRIPTION
Adiciona as depências de testes de frontend para viabilizar testes do react utilizando o redux.

Resolves #45 