### PR TITLE
Corrigir comandos de execução de checagem

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Caso alguma das checagens falhe, antes do commit ou antes do push, o procediment
 Uma das possíveis formas de se executar os scripts no frontend é executando o seguinte comando:
 ``` bash
 # 'npm' é o entrypoint
-$ sudo docker-compose up --build --rm frontend run [nome_do_script]
+$ sudo docker-compose run --rm frontend run [nome_do_script]
 ```
 
 ### API
@@ -68,7 +68,7 @@ $ sudo docker-compose up --build --rm frontend run [nome_do_script]
 Uma das possíveis formas de se executar os scripts da API é executando o seguinte comando:
 ``` bash
 # 'manage.py' é o entrypoint
-$ sudo docker-compose up --build --rm api [nome_do_script]
+$ sudo docker-compose run --rm api [nome_do_script]
 ```
 
 ### CodeClimate CLI


### PR DESCRIPTION
resolves #99 

Tinha sido colocado `up` ao invés de `build` no scripts.