### PR TITLE
Faz a URL da API facilmente trocável

### DIFF
--- a/unbrake-frontend/Dockerfile
+++ b/unbrake-frontend/Dockerfile
@@ -20,5 +20,7 @@ COPY scripts scripts
 COPY src src
 COPY hooks hooks
 
+ENV REACT_APP_API_URL "http://localhost:8000"
+
 ENTRYPOINT ["/app/frontend/entrypoint.dev"]
 CMD ["start"]

--- a/unbrake-frontend/src/components/ConfigurationForm.jsx
+++ b/unbrake-frontend/src/components/ConfigurationForm.jsx
@@ -4,8 +4,7 @@ import { initialize, Field, reduxForm } from "redux-form";
 import { TextField, Checkbox } from "redux-form-material-ui";
 import { withStyles, Button, FormControlLabel, Grid } from "@material-ui/core";
 import Request from "../utils/Request";
-
-const baseUrl = "http://localhost:8000/graphql";
+import { API_URL_GRAPHQL } from "../utils/Constants";
 
 const limits = (value, allValues) => {
   return parseInt(allValues.LSL, 10) >= parseInt(allValues.USL, 10)
@@ -189,7 +188,7 @@ const CommunGrid = (classes, type, handleChange) => {
 };
 
 async function submit(values, state) {
-  const url = `${baseUrl}?query=mutation{createConfig(number:${
+  const url = `${API_URL_GRAPHQL}?query=mutation{createConfig(number:${
     state.NOS
   },timeBetweenCycles:${state.TBS},upperLimit:${state.USL},inferiorLimit:${
     state.LSL

--- a/unbrake-frontend/src/components/Login.jsx
+++ b/unbrake-frontend/src/components/Login.jsx
@@ -8,9 +8,10 @@ import { withStyles } from "@material-ui/core/styles";
 import PropTypes from "prop-types";
 import Cookies from "universal-cookie";
 import Request from "../utils/Request";
+import { API_URL_GRAPHQL } from "../utils/Constants";
 
 const padding = 10;
-const baseUrl = "http://localhost:8000/graphql";
+const baseUrl = API_URL_GRAPHQL;
 const cookie = new Cookies();
 
 const styles = theme => ({

--- a/unbrake-frontend/src/components/SignUp.jsx
+++ b/unbrake-frontend/src/components/SignUp.jsx
@@ -7,9 +7,9 @@ import Paper from "@material-ui/core/Paper";
 import { withStyles } from "@material-ui/core/styles";
 import PropTypes from "prop-types";
 import history from "../utils/history";
+import { API_URL_GRAPHQL } from "../utils/Constants";
 
 const padding = 10;
-const baseUrl = "http://localhost:8000/graphql";
 
 const styles = theme => ({
   root: {
@@ -78,7 +78,9 @@ const signUpButton = (classes, submitting) => {
 
 export const submit = values => {
   return fetch(
-    `${baseUrl}?query=mutation{createUser(password: "${values.password}",
+    `${API_URL_GRAPHQL}?query=mutation{createUser(password: "${
+      values.password
+    }",
      username: "${values.username}"){user{id}}}`,
     {
       method: "POST"

--- a/unbrake-frontend/src/tests/Request.test.jsx
+++ b/unbrake-frontend/src/tests/Request.test.jsx
@@ -1,10 +1,10 @@
 import fetch from "jest-fetch-mock";
 import Request from "../utils/Request";
+import { API_URL_GRAPHQL } from "../utils/Constants";
 
 const Username = "OPA";
 const password = "password";
-const BaseUrl = "http://localhost:8000";
-const url = `${BaseUrl}/graphql?query=mutation{createUser(username:"${Username}",password:"${password}"){user{username}}}`;
+const url = `${API_URL_GRAPHQL}?query=mutation{createUser(username:"${Username}",password:"${password}"){user{username}}}`;
 const method = "POST";
 
 describe("Test request", () => {

--- a/unbrake-frontend/src/tests/SignUp.test.jsx
+++ b/unbrake-frontend/src/tests/SignUp.test.jsx
@@ -4,6 +4,7 @@ import toJson from "enzyme-to-json";
 import Adapter from "enzyme-adapter-react-16";
 import fetch from "jest-fetch-mock";
 import SignUp, { validate, submit } from "../components/SignUp";
+import { API_URL_GRAPHQL } from "../utils/Constants";
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -53,9 +54,7 @@ describe("submit", () => {
       .then(res => {
         response = res.data.createUser.username;
         expect(response).toBe(values.username);
-        expect(fetch.mock.calls[0][0]).toEqual(
-          "https://localhost:8000/graphql"
-        );
+        expect(fetch.mock.calls[0][0]).toEqual(API_URL_GRAPHQL);
       })
       .catch(() => {});
   });

--- a/unbrake-frontend/src/utils/Constants.jsx
+++ b/unbrake-frontend/src/utils/Constants.jsx
@@ -1,0 +1,2 @@
+export const API_URL = process.env.REACT_APP_API_URL;
+export const API_URL_GRAPHQL = `${API_URL}/graphql`;


### PR DESCRIPTION
resolves #123 

O frontend deve fazer requisições em URLs diferentes a depender se está em produção, desenvolvimento ou homologação mas a estrutura antiga não permitia essa flexibilização.

Esse PR facilita a personalização da rota através de variáveis de ambiente e cria um arquivo de constantes no frontend 