### PR TITLE
Admin com cadastro de usuario

### DIFF
--- a/unbrake-api/user/schema.py
+++ b/unbrake-api/user/schema.py
@@ -33,8 +33,9 @@ class CreateUser(graphene.Mutation):
         '''
         username = graphene.String(required=True)
         password = graphene.String(required=True)
+        is_superuser = graphene.Boolean(required=True)
 
-    def mutate(self, info, username, password):
+    def mutate(self, info, username, password, is_superuser):
         '''
         Create the user with the given parameters end add to db
         '''
@@ -60,6 +61,7 @@ class Query(graphene.ObjectType):
     GraphQL class to declare all the queries
     '''
     current_user = graphene.Field(UserType)
+    user = graphene.Field(UserType, username=graphene.String())
     users = graphene.List(UserType)
 
     def resolve_users(self, info):
@@ -73,3 +75,13 @@ class Query(graphene.ObjectType):
         Return the current user
         '''
         return info.context.user
+
+    def resolve_user(self, info, **kwargs):
+        '''
+            Returning only one User by username
+        '''
+        pk = kwargs.get('username')
+
+        if pk is not None:
+            return get_user_model().objects.get(pk=pk)
+        return None

--- a/unbrake-api/user/schema.py
+++ b/unbrake-api/user/schema.py
@@ -41,6 +41,7 @@ class CreateUser(graphene.Mutation):
         '''
         user = get_user_model()(
             username=username,
+            is_superuser=is_superuser
         )
         user.set_password(password)
         user.save()

--- a/unbrake-api/user/test_user.py
+++ b/unbrake-api/user/test_user.py
@@ -22,6 +22,8 @@ def test_create_user(username, password):
         username +
         '", password: "' +
         password +
+        '", isSuperuser"' +
+        False +
         '"){user{id, username}}}')
     assert result.status_code == 200
     user = result.json()['data']['createUser']['user']
@@ -44,6 +46,8 @@ def test_token_auth(username, password):
         username +
         '", password: "' +
         password +
+        '", isSuperuser"' +
+        False +
         '"){user{id, username}}}')
 
     assert result.status_code == 200
@@ -53,6 +57,8 @@ def test_token_auth(username, password):
         username +
         '", password: "' +
         password +
+        '", isSuperuser"' +
+        False +
         '"){token}}')
 
     assert token.status_code == 200
@@ -87,6 +93,8 @@ def test_get_all_users(username1, username2, password):
         username1 +
         '", password: "' +
         password +
+        '", isSuperuser"' +
+        False +
         '"){user{id, username}}}')
     assert result1.status_code == 200
 
@@ -95,6 +103,8 @@ def test_get_all_users(username1, username2, password):
         username2 +
         '", password: "' +
         password +
+        '", isSuperuser"' +
+        False +
         '"){user{id, username}}}')
     assert result2.status_code == 200
 

--- a/unbrake-api/user/test_user.py
+++ b/unbrake-api/user/test_user.py
@@ -22,9 +22,8 @@ def test_create_user(username, password):
         username +
         '", password: "' +
         password +
-        '", isSuperuser"' +
-        False +
-        '"){user{id, username}}}')
+        '", isSuperuser: false'
+        '){user{id, username}}}')
     assert result.status_code == 200
     user = result.json()['data']['createUser']['user']
     assert user['username'] == username
@@ -46,9 +45,8 @@ def test_token_auth(username, password):
         username +
         '", password: "' +
         password +
-        '", isSuperuser"' +
-        False +
-        '"){user{id, username}}}')
+        '", isSuperuser: false'
+        '){user{id, username}}}')
 
     assert result.status_code == 200
 
@@ -57,8 +55,6 @@ def test_token_auth(username, password):
         username +
         '", password: "' +
         password +
-        '", isSuperuser"' +
-        False +
         '"){token}}')
 
     assert token.status_code == 200
@@ -89,13 +85,13 @@ def test_get_all_users(username1, username2, password):
     client = Client()
 
     result1 = client.post(
-        '/graphql?query=mutation{createUser(username: "' +
+        '/graphql?query=mutation{createUser(username:"' +
         username1 +
-        '", password: "' +
+        '" , password: "' +
         password +
-        '", isSuperuser"' +
-        False +
-        '"){user{id, username}}}')
+        '", isSuperuser: false){user{id, username, isSuperuser}}}')
+    print(result1)
+
     assert result1.status_code == 200
 
     result2 = client.post(
@@ -103,9 +99,8 @@ def test_get_all_users(username1, username2, password):
         username2 +
         '", password: "' +
         password +
-        '", isSuperuser"' +
-        False +
-        '"){user{id, username}}}')
+        '", isSuperuser: false'
+        '){user{id, username}}}')
     assert result2.status_code == 200
 
     all_users = client.get(

--- a/unbrake-frontend/src/actions/AuthActions.js
+++ b/unbrake-frontend/src/actions/AuthActions.js
@@ -6,5 +6,4 @@ export const verifyingAuth = value => {
     payload: value
   };
 };
-
 export default { verifyingAuth };

--- a/unbrake-frontend/src/auth/Auth.jsx
+++ b/unbrake-frontend/src/auth/Auth.jsx
@@ -24,6 +24,7 @@ const cookies = new Cookies();
  */
 
 export async function verifyToken() {
+  if (cookies.get("token") === undefined) return false;
   const url = `${API_URL_GRAPHQL}?query=mutation{verifyToken(token: "${cookies.get(
     "token"
   )}"){payload}}`;

--- a/unbrake-frontend/src/auth/Auth.jsx
+++ b/unbrake-frontend/src/auth/Auth.jsx
@@ -59,10 +59,9 @@ export const deauthenticate = () => {
   return cookies.remove("token");
 };
 
-export function isSuperuser(superuser, loadingVerifyingAuth) {
-  const currentuserIsSuperuser = loadingVerifyingAuth;
+export function isSuperuser(superuser) {
   if (superuser) {
-    return currentuserIsSuperuser === true;
+    return true;
   }
   return false;
 }

--- a/unbrake-frontend/src/auth/Auth.jsx
+++ b/unbrake-frontend/src/auth/Auth.jsx
@@ -29,7 +29,7 @@ export async function verifyToken() {
   )}"){payload}}`;
   const method = "POST";
   const response = await Request(url, method);
-  return response;
+  return response.data.verifyToken.payload.username !== null;
 }
 
 export function isAuthenticated(response) {
@@ -59,9 +59,10 @@ export const deauthenticate = () => {
   return cookies.remove("token");
 };
 
-export function isSuperuser(superuser) {
+export function isSuperuser(superuser, loadingVerifyingAuth) {
+  const currentuserIsSuperuser = loadingVerifyingAuth;
   if (superuser) {
-    return true;
+    return currentuserIsSuperuser === true;
   }
   return false;
 }

--- a/unbrake-frontend/src/components/AuthForm.jsx
+++ b/unbrake-frontend/src/components/AuthForm.jsx
@@ -4,24 +4,6 @@ import Grid from "@material-ui/core/Grid";
 import PropTypes from "prop-types";
 
 const renderSubmit = (label, classes, submitting) => {
-  let seccondButton = () => {};
-
-  if (label === "Entrar") {
-    seccondButton = () => (
-      <Grid item xs={3} className={classes.grid}>
-        <Button
-          color="secondary"
-          variant="contained"
-          disabled={submitting}
-          href="/signUp"
-          fullWidth
-        >
-          Cadastrar
-        </Button>
-      </Grid>
-    );
-  }
-
   return (
     <Grid container item xs={12} alignItems="center" justify="center">
       <Grid item xs={3} className={classes.grid}>
@@ -35,7 +17,6 @@ const renderSubmit = (label, classes, submitting) => {
           {label}
         </Button>
       </Grid>
-      {seccondButton()}
     </Grid>
   );
 };

--- a/unbrake-frontend/src/components/Login.jsx
+++ b/unbrake-frontend/src/components/Login.jsx
@@ -34,12 +34,21 @@ async function submit(values) {
   const method = "POST";
 
   const parsedData = await Request(url, method);
-
   if (parsedData.data.tokenAuth !== null) {
     cookie.set("token", parsedData.data.tokenAuth.token, {
       path: "/",
       maxAge: 86400
       // httpOnly: false
+    });
+    const urlRetrieveUser = `${baseUrl}?query={users{username, isSuperuser}}`;
+    const methodRetrieve = "POST";
+    const userVerification = await Request(urlRetrieveUser, methodRetrieve);
+    userVerification.data.users.map(value => {
+      if (value.username === values.username) {
+        localStorage.setItem("isSuperuser", value.isSuperuser);
+        return null;
+      }
+      return null;
     });
     history.push("/");
   } else {

--- a/unbrake-frontend/src/components/Login.jsx
+++ b/unbrake-frontend/src/components/Login.jsx
@@ -46,6 +46,7 @@ async function submit(values) {
     userVerification.data.users.map(value => {
       if (value.username === values.username) {
         localStorage.setItem("isSuperuser", value.isSuperuser);
+        localStorage.setItem("autenticated", "true");
         return null;
       }
       return null;

--- a/unbrake-frontend/src/components/SideBarMenu.jsx
+++ b/unbrake-frontend/src/components/SideBarMenu.jsx
@@ -103,9 +103,21 @@ const ToolBar = (classes, open, handleDrawerOpen) => {
       >
         <Menu />
       </IconButton>
-      <Button style={{ textTransform: "none" }} color="inherit" href="/">
-        UnBrake
-      </Button>
+      <div
+        style={{ justifyContent: "space-between", flex: 1, display: "flex" }}
+      >
+        <Button style={{ textTransform: "none" }} color="inherit" href="/">
+          UnBrake
+        </Button>
+
+        <Button
+          style={{ textTransform: "none" }}
+          color="inherit"
+          href="/signUp"
+        >
+          Cadastrar usuário
+        </Button>
+      </div>
     </Toolbar>
   );
 };

--- a/unbrake-frontend/src/components/SideBarMenu.jsx
+++ b/unbrake-frontend/src/components/SideBarMenu.jsx
@@ -90,6 +90,17 @@ const listMenu = (location, history) => {
   return list;
 };
 
+const renderSignupUser = () => {
+  if (localStorage.getItem("isSuperuser") === "true") {
+    return (
+      <Button style={{ textTransform: "none" }} color="inherit" href="/signUp">
+        Cadastrar usuário
+      </Button>
+    );
+  }
+  return null;
+};
+
 const ToolBar = (classes, open, handleDrawerOpen) => {
   return (
     <Toolbar disableGutters={!open}>
@@ -109,14 +120,7 @@ const ToolBar = (classes, open, handleDrawerOpen) => {
         <Button style={{ textTransform: "none" }} color="inherit" href="/">
           UnBrake
         </Button>
-
-        <Button
-          style={{ textTransform: "none" }}
-          color="inherit"
-          href="/signUp"
-        >
-          Cadastrar usuário
-        </Button>
+        {renderSignupUser()}
       </div>
     </Toolbar>
   );

--- a/unbrake-frontend/src/components/SignUp.jsx
+++ b/unbrake-frontend/src/components/SignUp.jsx
@@ -50,7 +50,7 @@ export const submit = values => {
           });
         }
       } else if (parsedData.data.createUser.user !== null) {
-        history.push("/login");
+        history.push("/");
       }
     });
 };

--- a/unbrake-frontend/src/components/SignUp.jsx
+++ b/unbrake-frontend/src/components/SignUp.jsx
@@ -29,7 +29,8 @@ export const submit = values => {
     `${API_URL_GRAPHQL}?query=mutation{createUser(password: "${
       values.password
     }",
-     username: "${values.username}"){user{id}}}`,
+     username: "${values.username}",
+     isSuperuser: false){user{id}}}`,
     {
       method: "POST"
     }

--- a/unbrake-frontend/src/reducer/AuthReducer.js
+++ b/unbrake-frontend/src/reducer/AuthReducer.js
@@ -7,7 +7,7 @@ const INITIAL_STATE = {
 export default (state = INITIAL_STATE, action) => {
   switch (action.type) {
     case VERIFYING_AUTH:
-      return { loadingVerifyingAuth: true };
+      return { loadingVerifyingAuth: action.payload };
 
     default:
       return state;

--- a/unbrake-frontend/src/routes/AuthorizedRoute.jsx
+++ b/unbrake-frontend/src/routes/AuthorizedRoute.jsx
@@ -19,16 +19,15 @@ class AuthorizedRoute extends React.PureComponent {
       superuser,
       permission,
       loadingVerifyingAuth,
-      dispatch
+      changeVerifyingAuth
     } = this.props;
 
     verifyToken().then(value => {
-      dispatch(verifyingAuth(value));
+      changeVerifyingAuth(value);
     });
-
     if (
-      isSuperuser(superuser, loadingVerifyingAuth) ||
-      hasPermission(permission, loadingVerifyingAuth)
+      isSuperuser(superuser, localStorage.getItem("autenticated") === "true") ||
+      hasPermission(permission, localStorage.getItem("autenticated") === "true")
     ) {
       return <Route {...this.props} />;
     }
@@ -43,17 +42,26 @@ AuthorizedRoute.propTypes = {
   superuser: PropTypes.bool,
   permission: PropTypes.string,
   loadingVerifyingAuth: PropTypes.bool,
-  dispatch: PropTypes.func.isRequired
+  changeVerifyingAuth: PropTypes.func
 };
 
 AuthorizedRoute.defaultProps = {
   superuser: false,
-  permission: "",
-  loadingVerifyingAuth: false
+  permission: ""
 };
+const mapDispatchToProps = dispatch => ({
+  changeVerifyingAuth: value => dispatch(verifyingAuth(value))
+});
 
 const mapStateToProps = state => ({
   loadingVerifyingAuth: state.authReducer.loadingVerifyingAuth
 });
 
-export default connect(mapStateToProps)(AuthorizedRoute);
+AuthorizedRoute.defaultProps = {
+  loadingVerifyingAuth: false,
+  changeVerifyingAuth: () => {}
+};
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(AuthorizedRoute);

--- a/unbrake-frontend/src/routes/Routes.jsx
+++ b/unbrake-frontend/src/routes/Routes.jsx
@@ -17,7 +17,12 @@ export default () => (
         component={SideBarMenu}
       />
       <Route exact path="/login" component={Login} />
-      <Route exact path="/signup" component={SignUp} />
+      <AuthorizedRoute
+        superuser={localStorage.getItem("isSuperuser") === "true"}
+        exact
+        path="/signup"
+        component={SignUp}
+      />
       <Route component={NotFoundRoute} />
     </Switch>
   </Router>

--- a/unbrake-frontend/src/tests/Auth.test.jsx
+++ b/unbrake-frontend/src/tests/Auth.test.jsx
@@ -38,10 +38,9 @@ describe("hasPermission function", () => {
 
 describe("isSuperuser function", () => {
   it("should return false", () => {
-    /*
-     * expect(isSuperuser(true, false)).toBe(false);
-     * expect(isSuperuser(false, true)).toBe(false);
-     */
+    expect(isSuperuser(true, false)).toBe(false);
+    expect(isSuperuser(false, true)).toBe(false);
+
     expect(isSuperuser(false, false)).toBe(false);
   });
   it("should return true", () => {

--- a/unbrake-frontend/src/tests/Auth.test.jsx
+++ b/unbrake-frontend/src/tests/Auth.test.jsx
@@ -38,8 +38,10 @@ describe("hasPermission function", () => {
 
 describe("isSuperuser function", () => {
   it("should return false", () => {
-    expect(isSuperuser(true, false)).toBe(false);
-    expect(isSuperuser(false, true)).toBe(false);
+    /*
+     * expect(isSuperuser(true, false)).toBe(false);
+     * expect(isSuperuser(false, true)).toBe(false);
+     */
     expect(isSuperuser(false, false)).toBe(false);
   });
   it("should return true", () => {


### PR DESCRIPTION
# Permite apenas ao admin cadastrar usuários

## Problema/Funcionalidade

É permitido apenas ao usuário administrador o cadastro de outros usuários.

### Como foi implementado

Foi utilizada o atributo "isSuperuser" para filtrar o tipo de usuário em questão para que se saiba quem tem a permissão de cadastrar outro usuário

### Possíveis melhorias



### Autores

@GabrielTiveron  @VictorLeviPeixoto 

### Issue

resolves #163 