### PR TITLE
Selecionar configurações no banco de dados

### DIFF
--- a/unbrake-api/calibration/models.py
+++ b/unbrake-api/calibration/models.py
@@ -1,12 +1,12 @@
 '''
     This is the models file of calibration app.
     The models of calibration are divided in:
-        Calibration Validation,
-        Calibration Force,
-        Calibration Speed,
-        Calibration Relations,
-        Calibration Temperature,
-        Calibration Command.
+    Calibration Validation,
+    Calibration Force,
+    Calibration Speed,
+    Calibration Relations,
+    Calibration Temperature,
+    Calibration Command.
     The classes are based on the defcalibra file
 '''
 
@@ -77,6 +77,7 @@ class Calibration(models.Model):
     '''
         This class has all the information of a calibration definition.
     '''
+
     name = models.CharField(max_length=15, null=False, blank=False)
     is_default = models.BooleanField(null=False, blank=False)
     vibration = models.OneToOneField(

--- a/unbrake-api/calibration/models.py
+++ b/unbrake-api/calibration/models.py
@@ -77,6 +77,8 @@ class Calibration(models.Model):
     '''
         This class has all the information of a calibration definition.
     '''
+    name = models.CharField(max_length=15, null=False, blank=False)
+    is_default = models.BooleanField(null=False, blank=False)
     vibration = models.OneToOneField(
         CalibrationVibration, on_delete=models.CASCADE)
     speed = models.OneToOneField(

--- a/unbrake-api/calibration/mutation.py
+++ b/unbrake-api/calibration/mutation.py
@@ -245,6 +245,7 @@ class CreateCalibration(graphene.Mutation):
         '''
             Arguments required to create a new Calibration
         '''
+        name = graphene.String()
         id_vibration = graphene.Int()
         id_first_force = graphene.Int()
         id_second_force = graphene.Int()
@@ -257,6 +258,7 @@ class CreateCalibration(graphene.Mutation):
     def mutate(
             self,
             info,
+            name,
             id_vibration,
             id_first_force,
             id_second_force,
@@ -280,6 +282,8 @@ class CreateCalibration(graphene.Mutation):
         command = CalibrationCommand.objects.get(id=id_command)
 
         calibration = Calibration(
+            name=name,
+            is_default=False,
             vibration=vibration,
             speed=speed,
             relations=relations,

--- a/unbrake-api/calibration/test_mutation.py
+++ b/unbrake-api/calibration/test_mutation.py
@@ -72,6 +72,7 @@ RESPONSE_RELATIONS = {
 }
 
 RESPONSE_CALIBRATION = {
+    'name': "Teste",
     'speed': RESPONSE_SPEED,
     'vibration': RESPONSE_VIBRATION,
     'command': RESPONSE_COMMAND,
@@ -237,10 +238,10 @@ def test_mutation_calibrate():
     CLIENT.post(url)
 
     url = ('/graphql?query=mutation{createCalibration(idVibration: 1,'
-           ' idSpeed:1, idCommand: 1, idRelations: 1,'
+           'name: "Teste", idSpeed:1, idCommand: 1, idRelations: 1,'
            ' idFirstForce: 1, idSecondForce: 2, idFirstTemperature: 1,'
            'idSecondTemperature: 2){calibration'
-           '{speed {acquisitionChanel, tireRadius}, '
+           '{name, speed {acquisitionChanel, tireRadius}, '
            'vibration {acquisitionChanel, conversionFactor, vibrationOffset}'
            'command {commandChanelSpeed, actualSpeed, maxSpeed,'
            'chanelCommandPression, actualPression, maxPression},'
@@ -259,7 +260,7 @@ def test_mutation_calibrate():
 
     get_calibration = CLIENT.get(
         '/graphql?query=query{calibration(id:1)'
-        '{speed {acquisitionChanel, tireRadius}, '
+        '{name, speed {acquisitionChanel, tireRadius}, '
         'vibration {acquisitionChanel, conversionFactor, vibrationOffset}'
         'command {commandChanelSpeed, actualSpeed, maxSpeed,'
         'chanelCommandPression, actualPression, maxPression},'
@@ -277,7 +278,7 @@ def test_mutation_calibrate():
 
     get_all_calibration = CLIENT.get(
         '/graphql?query=query{allCalibration'
-        '{speed {acquisitionChanel, tireRadius}, '
+        '{name, speed {acquisitionChanel, tireRadius}, '
         'vibration {acquisitionChanel, conversionFactor, vibrationOffset}'
         'command {commandChanelSpeed, actualSpeed, maxSpeed,'
         'chanelCommandPression, actualPression, maxPression},'

--- a/unbrake-api/configuration/models.py
+++ b/unbrake-api/configuration/models.py
@@ -32,3 +32,9 @@ class Config(models.Model):
         null=True,
         max_digits=10,
         decimal_places=6)
+
+    def __str__(self):
+        '''
+            Define the way the objects are shown
+        '''
+        return "Id: " + str(self.id) + " - " + "Name: " + self.name

--- a/unbrake-api/configuration/models.py
+++ b/unbrake-api/configuration/models.py
@@ -12,6 +12,8 @@ class Config(models.Model):
     '''
     This class is based on the configuration file, and describe an entire test
     '''
+    name = models.CharField(max_length=15)
+    is_default = models.BooleanField()
     number = models.PositiveIntegerField()
     time_between_cycles = models.PositiveIntegerField()
     upper_limit = models.IntegerField()

--- a/unbrake-api/configuration/schema.py
+++ b/unbrake-api/configuration/schema.py
@@ -111,7 +111,7 @@ class Query:
         disable_shutdown=graphene.Boolean(),
         enable_output=graphene.Boolean(),
         temperature=graphene.Float(),
-        Time=graphene.Float())
+        time=graphene.Float())
 
     config = graphene.Field(
         ConfigType,
@@ -127,7 +127,9 @@ class Query:
         disable_shutdown=graphene.Boolean(),
         enable_output=graphene.Boolean(),
         temperature=graphene.Float(),
-        Time=graphene.Float())
+        time=graphene.Float())
+
+    config_default = graphene.List(ConfigType)
 
     def resolve_all_config(self, info, **kwargs):
         '''
@@ -151,3 +153,9 @@ class Query:
 
         return Config.objects.get(name=name)
 
+    def resolve_config_default(self, info):
+        '''
+        Return a list with all the Config objects with is_default equal true
+        '''
+
+        return Config.objects.exclude(is_default=False)

--- a/unbrake-api/configuration/schema.py
+++ b/unbrake-api/configuration/schema.py
@@ -49,7 +49,6 @@ class CreateConfig(graphene.Mutation):
             self,
             info,
             name,
-            is_default,
             number,
             time_between_cycles,
             upper_limit,
@@ -61,11 +60,15 @@ class CreateConfig(graphene.Mutation):
             temperature,
             time):
         '''
+<<<<<<< HEAD
         Create the Config with the given parameters end add to db
+=======
+        Create the config with the given parameters end add to db
+>>>>>>> Create mutates to create a config default
         '''
         config = Config(
             name=name,
-            is_default=is_default,
+            is_default=False,
             number=number,
             time_between_cycles=time_between_cycles,
             upper_limit=upper_limit,
@@ -80,6 +83,73 @@ class CreateConfig(graphene.Mutation):
         config.save()
 
         return CreateConfig(config=config)
+
+
+class CreateDefaultConfig(graphene.Mutation):
+    # pylint: disable =  unused-argument, no-self-use, too-many-arguments
+    # pylint: disable = too-many-locals
+    '''
+    Class to create a new default Config object on db
+    '''
+    config = graphene.Field(ConfigType)
+
+    class Arguments:
+        '''
+        Arguments required to create a new config
+        '''
+        name = graphene.String()
+        is_default = graphene.Boolean()
+        number = graphene.Int()
+        time_between_cycles = graphene.Int()
+        upper_limit = graphene.Int()
+        inferior_limit = graphene.Int()
+        upper_time = graphene.Int()
+        inferior_time = graphene.Int()
+        disable_shutdown = graphene.Boolean()
+        enable_output = graphene.Boolean()
+        temperature = graphene.Float()
+        time = graphene.Float()
+
+    def mutate(
+            self,
+            info,
+            number,
+            name,
+            time_between_cycles,
+            upper_limit,
+            inferior_limit,
+            upper_time,
+            inferior_time,
+            disable_shutdown,
+            enable_output,
+            temperature,
+            time):
+        '''
+            Set the othes default config as a ordinary Config
+            and define a new default Config
+        '''
+        last_default_config = Config.objects.exclude(is_default=False)
+
+        for i in last_default_config:
+            i.is_default = False
+
+        config = Config(
+            name=name,
+            is_default=True,
+            number=number,
+            time_between_cycles=time_between_cycles,
+            upper_limit=upper_limit,
+            inferior_limit=inferior_limit,
+            upper_time=upper_time,
+            inferior_time=inferior_time,
+            disable_shutdown=disable_shutdown,
+            enable_output=enable_output,
+            temperature=temperature,
+            time=time,
+        )
+        config.save()
+
+        return CreateDefaultConfig(config=config)
 
 
 class Mutation(graphene.ObjectType):
@@ -131,6 +201,8 @@ class Query:
 
     config_default = graphene.List(ConfigType)
 
+    config_not_default = graphene.List(ConfigType)
+
     def resolve_all_config(self, info, **kwargs):
         '''
             Returning all CyclesConfig on db
@@ -157,5 +229,10 @@ class Query:
         '''
         Return a list with all the Config objects with is_default equal true
         '''
-
         return Config.objects.exclude(is_default=False)
+
+    def resolve_config_not_default(self, info):
+        '''
+        Return a list with all the Config objects with is_default equal false
+        '''
+        return Config.objects.exclude(is_default=True)

--- a/unbrake-api/configuration/schema.py
+++ b/unbrake-api/configuration/schema.py
@@ -22,6 +22,7 @@ class ConfigType(DjangoObjectType):
 
 class CreateConfig(graphene.Mutation):
     # pylint: disable =  unused-argument, no-self-use, too-many-arguments
+    # pylint: disable = too-many-locals
     '''
     Class to create a new Config object on db
     '''
@@ -31,6 +32,8 @@ class CreateConfig(graphene.Mutation):
         '''
         Arguments required to create a new config
         '''
+        name = graphene.String()
+        is_default = graphene.Boolean()
         number = graphene.Int()
         time_between_cycles = graphene.Int()
         upper_limit = graphene.Int()
@@ -42,13 +45,27 @@ class CreateConfig(graphene.Mutation):
         temperature = graphene.Float()
         time = graphene.Float()
 
-    def mutate(self, info, number, time_between_cycles, upper_limit,
-               inferior_limit, upper_time, inferior_time, disable_shutdown,
-               enable_output, temperature, time):
+    def mutate(
+            self,
+            info,
+            name,
+            is_default,
+            number,
+            time_between_cycles,
+            upper_limit,
+            inferior_limit,
+            upper_time,
+            inferior_time,
+            disable_shutdown,
+            enable_output,
+            temperature,
+            time):
         '''
         Create the Config with the given parameters end add to db
         '''
         config = Config(
+            name=name,
+            is_default=is_default,
             number=number,
             time_between_cycles=time_between_cycles,
             upper_limit=upper_limit,
@@ -77,9 +94,14 @@ class Query:
     '''
         The Query list all the types created above
     '''
-    config = graphene.Field(
+
+    all_config = graphene.List(ConfigType)
+
+    config_at = graphene.Field(
         ConfigType,
         id=graphene.Int(),
+        name=graphene.String(),
+        is_default=graphene.Boolean(),
         number=graphene.Int(),
         time_between_cycles=graphene.Int(),
         upper_limit=graphene.Int(),
@@ -91,7 +113,21 @@ class Query:
         temperature=graphene.Float(),
         Time=graphene.Float())
 
-    all_config = graphene.List(ConfigType)
+    config = graphene.Field(
+        ConfigType,
+        id=graphene.Int(),
+        name=graphene.String(),
+        is_default=graphene.Boolean(),
+        number=graphene.Int(),
+        time_between_cycles=graphene.Int(),
+        upper_limit=graphene.Int(),
+        inferior_limit=graphene.Int(),
+        upper_time=graphene.Int(),
+        inferior_time=graphene.Int(),
+        disable_shutdown=graphene.Boolean(),
+        enable_output=graphene.Boolean(),
+        temperature=graphene.Float(),
+        Time=graphene.Float())
 
     def resolve_all_config(self, info, **kwargs):
         '''
@@ -99,10 +135,19 @@ class Query:
         '''
         return Config.objects.all()
 
-    def resolve_config(self, info, **kwargs):
+    def resolve_config_at(self, info, **kwargs):
         '''
-            Returning only one CyclesConfig by id
+            Returning only one Config by id
         '''
         pk = kwargs.get('id')
 
         return Config.objects.get(pk=pk)
+
+    def resolve_config(self, info, **kwargs):
+        '''
+            Return one config by name
+        '''
+        name = kwargs.get('name')
+
+        return Config.objects.get(name=name)
+

--- a/unbrake-api/configuration/schema.py
+++ b/unbrake-api/configuration/schema.py
@@ -60,11 +60,7 @@ class CreateConfig(graphene.Mutation):
             temperature,
             time):
         '''
-<<<<<<< HEAD
         Create the Config with the given parameters end add to db
-=======
-        Create the config with the given parameters end add to db
->>>>>>> Create mutates to create a config default
         '''
         config = Config(
             name=name,

--- a/unbrake-api/configuration/schema.py
+++ b/unbrake-api/configuration/schema.py
@@ -126,26 +126,40 @@ class CreateDefaultConfig(graphene.Mutation):
         '''
         last_default_config = Config.objects.exclude(is_default=False)
 
-        for i in last_default_config:
-            i.is_default = False
+        if not last_default_config.exists():
 
-        config = Config(
-            name=name,
-            is_default=True,
-            number=number,
-            time_between_cycles=time_between_cycles,
-            upper_limit=upper_limit,
-            inferior_limit=inferior_limit,
-            upper_time=upper_time,
-            inferior_time=inferior_time,
-            disable_shutdown=disable_shutdown,
-            enable_output=enable_output,
-            temperature=temperature,
-            time=time,
-        )
-        config.save()
+            config = Config(
+                name=name,
+                is_default=True,
+                number=number,
+                time_between_cycles=time_between_cycles,
+                upper_limit=upper_limit,
+                inferior_limit=inferior_limit,
+                upper_time=upper_time,
+                inferior_time=inferior_time,
+                disable_shutdown=disable_shutdown,
+                enable_output=enable_output,
+                temperature=temperature,
+                time=time,
+            )
+            config.save()
 
-        return CreateDefaultConfig(config=config)
+            return CreateDefaultConfig(config=config)
+
+        last_default_config[0].name = name
+        last_default_config[0].is_default = True
+        last_default_config[0].number = number
+        last_default_config[0].time_between_cycles = time_between_cycles
+        last_default_config[0].upper_limit = upper_limit
+        last_default_config[0].inferior_limit = inferior_limit
+        last_default_config[0].upper_time = upper_time
+        last_default_config[0].inferior_time = inferior_time
+        last_default_config[0].disable_shutdown = disable_shutdown
+        last_default_config[0].enable_output = enable_output
+        last_default_config[0].temperature = temperature
+        last_default_config[0].time = time
+
+        return CreateDefaultConfig(config=last_default_config[0])
 
 
 class Mutation(graphene.ObjectType):
@@ -153,6 +167,7 @@ class Mutation(graphene.ObjectType):
     GraphQL class to declare all the mutations
     '''
     create_config = CreateConfig.Field()
+    create_default_config = CreateDefaultConfig.Field()
 
 
 class Query:

--- a/unbrake-api/configuration/test_models.py
+++ b/unbrake-api/configuration/test_models.py
@@ -7,8 +7,6 @@ from django.test import Client
 from configuration.models import Config
 
 CLIENT = Client()
-
-
 # First argument are the parameters names
 # Second is a tuple of params
 # First argument of param is the first parameter name and so on

--- a/unbrake-api/configuration/test_models.py
+++ b/unbrake-api/configuration/test_models.py
@@ -17,7 +17,8 @@ CLIENT = Client()
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     ("parameters"), (
-        pytest.param([10, 20, 32, 16, 5, 5, True, False, 64, 51],
+        pytest.param([10, 20, 32, 16, 5, 5, True, False, 64, 51,
+                      'teste', False],
                      id='config_test_1'),
     )
 )
@@ -37,6 +38,8 @@ def test_config(parameters):
     enable_output_aux = parameters[7]
     temperature_aux = parameters[8]
     time_aux = parameters[9]
+    name_aux = parameters[10]
+    is_default_aux = parameters[11]
 
     response = {'number': number_aux,
                 'timeBetweenCycles': time_between_cycles_aux,
@@ -47,7 +50,9 @@ def test_config(parameters):
                 'disableShutdown': disable_shutdown_aux,
                 'enableOutput': enable_output_aux,
                 'temperature': temperature_aux,
-                'time': time_aux
+                'name': name_aux,
+                'isDefault': is_default_aux,
+                'time': time_aux,
                 }
 
     Config(
@@ -60,24 +65,26 @@ def test_config(parameters):
         disable_shutdown=disable_shutdown_aux,
         enable_output=enable_output_aux,
         temperature=temperature_aux,
+        name=name_aux,
+        is_default=is_default_aux,
         time=time_aux,
     ).save()
 
     result = CLIENT.get(
-        '/graphql?query={config(id: 1){number, timeBetweenCycles, upperLimit,'
+        '/graphql?query={configAt(id: 1){number,timeBetweenCycles,upperLimit,'
         'inferiorLimit, upperTime, inferiorTime,'
-        'disableShutdown, enableOutput, temperature,time}}')
+        'disableShutdown, enableOutput, temperature,name, isDefault,time}}')
 
     assert result.status_code == 200
-    cycles_config = result.json()['data']['config']
 
-    assert cycles_config == response
+    assert result.json()['data']['configAt'] == response
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     ("parameters"), (
-        pytest.param([10, 20, 32, 16, 5, 5, 'true', 'false', 64, 51],
+        pytest.param([10, 20, 32, 16, 5, 5, 'true', 'false', 64, 51, 'teste',
+                      'false'],
                      id='create_config_test_1'),
     )
 )
@@ -97,6 +104,8 @@ def test_create_config(parameters):
     enable_output = parameters[7]
     temperature = parameters[8]
     time = parameters[9]
+    name = parameters[10]
+    is_default = parameters[11]
 
     create = CLIENT.post(
         '/graphql?query=mutation{createConfig'
@@ -109,24 +118,19 @@ def test_create_config(parameters):
         'disableShutdown: ' + str(disable_shutdown) + ', '
         'enableOutput: ' + str(enable_output) + ', '
         'temperature: ' + str(temperature) + ', '
+        'name: "' + str(name) + '", '
+        'isDefault: ' + str(is_default) + ', '
         'time: ' + str(time) + ')'
         '{config{number, timeBetweenCycles,upperLimit,inferiorLimit,'
         'upperTime, inferiorTime, disableShutdown,'
-        'enableOutput, temperature, time}}}')
-    first_sataus_code = create.status_code == 200
+        'enableOutput, temperature,name, isDefault, time}}}')
+    assert create.status_code == 200
 
     result = CLIENT.get(
-        '/graphql?query=query{config(id: 1){number, timeBetweenCycles,'
+        '/graphql?query=query{configAt(id: 1){number, timeBetweenCycles,'
         ' upperLimit, inferiorLimit, upperTime, inferiorTime,'
-        'disableShutdown, enableOutput, temperature,time}}')
-    assert result.status_code == 200 and first_sataus_code
+        'disableShutdown, enableOutput, temperature, name, isDefault,time}}')
+    assert result.status_code == 200
 
-    assert create.json()['data']['createConfig'] == result.json()['data']
-
-    get_all = CLIENT.get(
-        '/graphql?query=query{allConfig{number, timeBetweenCycles,'
-        ' upperLimit, inferiorLimit, upperTime, inferiorTime,'
-        'disableShutdown, enableOutput, temperature,time}}')
-    assert get_all.status_code == 200
-    result = result.json()['data']['config']
-    assert result == get_all.json()['data']['allConfig'][0]
+    assert create.json()['data']['createConfig']['config'] == result.json()[
+        'data']['configAt']

--- a/unbrake-api/configuration/test_models.py
+++ b/unbrake-api/configuration/test_models.py
@@ -105,7 +105,6 @@ def test_create_config(parameters):
     temperature = parameters[8]
     time = parameters[9]
     name = parameters[10]
-    is_default = parameters[11]
 
     create = CLIENT.post(
         '/graphql?query=mutation{createConfig'
@@ -119,7 +118,6 @@ def test_create_config(parameters):
         'enableOutput: ' + str(enable_output) + ', '
         'temperature: ' + str(temperature) + ', '
         'name: "' + str(name) + '", '
-        'isDefault: ' + str(is_default) + ', '
         'time: ' + str(time) + ')'
         '{config{number, timeBetweenCycles,upperLimit,inferiorLimit,'
         'upperTime, inferiorTime, disableShutdown,'

--- a/unbrake-api/configuration/test_models.py
+++ b/unbrake-api/configuration/test_models.py
@@ -14,6 +14,8 @@ CLIENT = Client()
 # First argument of param is the first parameter name and so on
 # id is like the name for the test case
 # Is possible to test only one test case with: pytest [file] -k [id]
+
+
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     ("parameters"), (

--- a/unbrake-frontend/src/App.jsx
+++ b/unbrake-frontend/src/App.jsx
@@ -5,7 +5,13 @@ import { createStore, applyMiddleware } from "redux";
 import { MuiThemeProvider, createMuiTheme } from "@material-ui/core/styles";
 import thunk from "redux-thunk";
 import reducers from "./reducer/index";
+<<<<<<< HEAD
 import Routes from "./routes/Routes";
+=======
+
+// import Routes from "./routes/Routes";
+import Configuration from "./components/Configuration";
+>>>>>>> Creat Select Component
 
 const theme = createMuiTheme({
   palette: {
@@ -29,7 +35,8 @@ const App = () => (
   <Provider store={store}>
     <MuiThemeProvider theme={theme}>
       <React.Fragment>
-        <Routes />
+        {/* <Routes /> */}
+        <Configuration />
       </React.Fragment>
     </MuiThemeProvider>
   </Provider>

--- a/unbrake-frontend/src/App.jsx
+++ b/unbrake-frontend/src/App.jsx
@@ -29,8 +29,7 @@ const App = () => (
   <Provider store={store}>
     <MuiThemeProvider theme={theme}>
       <React.Fragment>
-        {/* <Routes /> */}
-        <Configuration />
+        <Routes />
       </React.Fragment>
     </MuiThemeProvider>
   </Provider>

--- a/unbrake-frontend/src/App.jsx
+++ b/unbrake-frontend/src/App.jsx
@@ -5,13 +5,7 @@ import { createStore, applyMiddleware } from "redux";
 import { MuiThemeProvider, createMuiTheme } from "@material-ui/core/styles";
 import thunk from "redux-thunk";
 import reducers from "./reducer/index";
-<<<<<<< HEAD
 import Routes from "./routes/Routes";
-=======
-
-// import Routes from "./routes/Routes";
-import Configuration from "./components/Configuration";
->>>>>>> Creat Select Component
 
 const theme = createMuiTheme({
   palette: {

--- a/unbrake-frontend/src/components/Calibration/Vibration.jsx
+++ b/unbrake-frontend/src/components/Calibration/Vibration.jsx
@@ -6,23 +6,30 @@ import styles from "../Styles";
 import RealTimeChart from "../RealTimeChart";
 import { checkbox, field } from "./CalibrationComponents";
 
+const renderField = (states, classes, handleChange) => {
+  return (
+    <Grid alignItems="center" justify="center" container item xs={6}>
+      {field(states, classes, handleChange)}
+    </Grid>
+  );
+};
+
 const freeFields = (states, classes, handleChange) => {
   const fields = states.map(value => {
     return (
-      <Grid key={value.name} item xs={6}>
-        {field(value, classes, handleChange)}
-      </Grid>
+      <React.Fragment>
+        {renderField(value, classes, handleChange)}
+      </React.Fragment>
     );
   });
   return fields;
 };
 
-const vibrationUnits = (states, style, handleChange) => {
+const vibrationUnits = (states, classes, handleChange) => {
   return (
     <Grid alignItems="center" container justify="center" item xs={12}>
-      <Grid alignItems="center" justify="center" container item xs={6}>
-        {field(states[0], style, handleChange)}
-      </Grid>
+      {renderField(states[0], classes, handleChange)}
+
       <Grid alignItems="center" justify="center" container item xs={6}>
         {checkbox(states[1], handleChange)}
       </Grid>
@@ -34,17 +41,13 @@ const allFields = (states, classes, handleChange) => {
   return (
     <Grid alignItems="center" justify="center" container item xs={12}>
       <Grid item xs={12}>
-        <Grid alignItems="center" justify="center" container item xs={6}>
-          {field(states[0], classes, handleChange)}
-        </Grid>
+        {renderField(states[0], classes, handleChange)}
       </Grid>
 
       {vibrationUnits(states[1], classes, handleChange)}
       {vibrationUnits(states[2], classes, handleChange)}
 
-      <Grid alignItems="center" justify="center" container item xs={12}>
-        {freeFields(states[3], classes, handleChange)}
-      </Grid>
+      {freeFields(states[3], classes, handleChange)}
     </Grid>
   );
 };
@@ -67,9 +70,9 @@ class Vibration extends React.Component {
   }
 
   handleChange(event) {
-    const { target } = event;
-    const value = target.type === "checkbox" ? target.checked : target.value;
-    const vibration = { [event.target.name]: value };
+    const { name, type, value, checked } = event;
+    const newValue = type === "checkbox" ? checked : value;
+    const vibration = { [name]: newValue };
     this.setState(prevState => ({
       vibration: { ...prevState.vibration, ...vibration }
     }));

--- a/unbrake-frontend/src/components/Calibration/Vibration.jsx
+++ b/unbrake-frontend/src/components/Calibration/Vibration.jsx
@@ -10,7 +10,6 @@ const renderField = (states, classes, handleChange) => {
   return (
     <Grid alignItems="center" justify="center" container item xs={6}>
       {field(states, classes, handleChange)}
-
     </Grid>
   );
 };

--- a/unbrake-frontend/src/components/Configuration.jsx
+++ b/unbrake-frontend/src/components/Configuration.jsx
@@ -25,43 +25,9 @@ const styles = () => ({
   }
 });
 
-let allConfig = [{ id: 0, name: "" }];
-
-async function getConfigurationsId() {
-  const url = `${API_URL_GRAPHQL}?query=query{allConfig{id, name}}`;
-
-  const method = "POST";
-
-  const response = await Request(url, method);
-
-  allConfig = [{ id: 0, name: "" }];
-
-  allConfig = allConfig.concat(response.data.allConfig);
-  /*
-   * const one = 1;
-   * const zero = 0;
-   */
-
-  // let i;
-
-  /*
-   * for (i = zero; i < response.data.allConfig.length; i += one) {
-   *   allConfig[i + one] = response.data.allConfig[i];
-   *   // console.log(allConfig[i]);
-   * }
-   */
-
-  // console.log(allConfig.length);
-
-  // return response.data.allConfig;
-}
-
-const itensSelection = () => {
-  getConfigurationsId();
-  /*
-   * console.log("ConfigurationsTest", allConfig[0]);
-   * console.log(allConfig.length);
-   */
+const itensSelection = allConfiguration => {
+  let allConfig = [{ id: 0, name: "" }];
+  allConfig = allConfig.concat(allConfiguration);
 
   const itens = allConfig.map(value => {
     return (
@@ -73,23 +39,23 @@ const itensSelection = () => {
   return itens;
 };
 
-const selectConfiguration = (handleChange, dataBaseConfiguration, classes) => {
+const selectConfiguration = (handleChange, configStates, classes) => {
   return (
     <Grid item xs={4} className={classes.title}>
       <FormControl variant="outlined" className={classes.formControl}>
         <InputLabel htmlFor="outlined-age-simple">Configurações</InputLabel>
         <Select
-          value={dataBaseConfiguration}
+          value={configStates[0]}
           onChange={handleChange}
           input={
             <OutlinedInput
-              labelWidth={dataBaseConfiguration}
+              labelWidth={configStates[0]}
               name="dataBaseConfiguration"
               id="outlined-age-simple"
             />
           }
         >
-          {itensSelection()}
+          {itensSelection(configStates[1])}
         </Select>
       </FormControl>
     </Grid>
@@ -115,11 +81,22 @@ class Configuration extends React.Component {
           UWT: ""
         }
       },
-      dataBaseConfiguration: 0
+      dataBaseConfiguration: 0,
+      allConfiguration: ""
     };
 
     this.handleChange = this.handleChange.bind(this);
     this.fileUpload = this.fileUpload.bind(this);
+  }
+
+  componentDidMount() {
+    const url = `${API_URL_GRAPHQL}?query=query{allConfig{id, name}}`;
+    const method = "POST";
+    Request(url, method).then(json => {
+      const { data } = json.data;
+      const { allConfig } = data.allConfig;
+      this.setState({ allConfiguration: allConfig });
+    });
   }
 
   handleChange(event) {
@@ -160,15 +137,19 @@ class Configuration extends React.Component {
       const content = e.target.result;
       const fileUpload = iniparser.parseString(content);
       scope.setState({ configuration: fileUpload });
-      // console.log(fileUpload);
     };
 
     reader.readAsText(file, "UTF-8");
   }
 
   render() {
-    const { configuration, dataBaseConfiguration } = this.state;
     const { classes } = this.props;
+    const {
+      configuration,
+      dataBaseConfiguration,
+      allConfiguration
+    } = this.state;
+    const configStates = [dataBaseConfiguration, allConfiguration];
 
     return (
       <Grid
@@ -180,7 +161,7 @@ class Configuration extends React.Component {
       >
         {this.uploadField("configuration")}
 
-        {selectConfiguration(this.handleChange, dataBaseConfiguration, classes)}
+        {selectConfiguration(this.handleChange, configStates, classes)}
         <ConfigurationForm configuration={configuration} />
       </Grid>
     );

--- a/unbrake-frontend/src/components/Configuration.jsx
+++ b/unbrake-frontend/src/components/Configuration.jsx
@@ -17,7 +17,7 @@ import styles from "./ConfigurationStyles";
 const query =
   "id, name, number, time, temperature, timeBetweenCycles, upperLimit, inferiorLimit, upperTime, inferiorTime, disableShutdown, enableOutput";
 
-async function submit(configuration, name) {
+export async function submit(configuration, name) {
   const { TAS, TAT, TMO, TAO, UWT, NOS, LSL, USL, TBS, LWT } = configuration;
   if (name === "" || name === undefined) return;
 

--- a/unbrake-frontend/src/components/Configuration.jsx
+++ b/unbrake-frontend/src/components/Configuration.jsx
@@ -26,6 +26,9 @@ const styles = () => ({
   }
 });
 
+const query =
+  "id, name, number, time, temperature, timeBetweenCycles, upperLimit, inferiorLimit, upperTime, inferiorTime, disableShutdown, enableOutput";
+
 const itensSelection = allConfiguration => {
   let allConfig = [{ id: 0, name: "" }];
   allConfig = allConfig.concat(allConfiguration);
@@ -100,7 +103,7 @@ class Configuration extends React.Component {
   }
 
   handleUpDefault() {
-    const url = `${API_URL_GRAPHQL}?query=query{configDefault{id, name, number, time, temperature, timeBetweenCycles, upperLimit, inferiorLimit, upperTime, inferiorTime, disableShutdown, enableOutput}}`;
+    const url = `${API_URL_GRAPHQL}?query=query{configDefault{${query}}}`;
 
     const method = "GET";
 
@@ -128,6 +131,34 @@ class Configuration extends React.Component {
 
   handleChange(event) {
     this.setState({ [event.target.name]: event.target.value });
+    this.handleSelectConfig(event.target.value);
+  }
+
+  handleSelectConfig(id) {
+    const url = `${API_URL_GRAPHQL}?query=query{configAt(id:${id}){${query}}}`;
+
+    const method = "GET";
+
+    Request(url, method).then(response => {
+      const data = response.data.configAt;
+
+      const configurationDefault = {
+        CONFIG_ENSAIO: {
+          LSL: data.inferiorLimit,
+          LWT: data.inferiorTime,
+          NOS: data.number,
+          TAO: data.enableOutput,
+          TAS: data.temperature,
+          TAT: data.time,
+          TBS: data.timeBetweenCycles,
+          TMO: data.disableShutdown,
+          USL: data.upperLimit,
+          UWT: data.upperTime
+        }
+      };
+
+      this.setState({ configuration: configurationDefault });
+    });
   }
 
   uploadField(field) {

--- a/unbrake-frontend/src/components/Configuration.jsx
+++ b/unbrake-frontend/src/components/Configuration.jsx
@@ -9,6 +9,7 @@ import InputLabel from "@material-ui/core/InputLabel";
 import MenuItem from "@material-ui/core/MenuItem";
 import FormControl from "@material-ui/core/FormControl";
 import Select from "@material-ui/core/Select";
+import Button from "@material-ui/core/Button";
 import ConfigurationForm from "./ConfigurationForm";
 import { API_URL_GRAPHQL } from "../utils/Constants";
 import Request from "../utils/Request";
@@ -71,7 +72,6 @@ class Configuration extends React.Component {
           LSL: "",
           LWT: "",
           NOS: "",
-          PTD: "",
           TAO: false,
           TAS: "",
           TAT: "",
@@ -85,17 +85,44 @@ class Configuration extends React.Component {
       allConfiguration: ""
     };
 
+    this.handleUpDefault = this.handleUpDefault.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.fileUpload = this.fileUpload.bind(this);
   }
 
   componentDidMount() {
-    const url = `${API_URL_GRAPHQL}?query=query{allConfig{id, name}}`;
-    const method = "POST";
+    const url = `${API_URL_GRAPHQL}?query=query{configNotDefault{id, name}}`;
+    const method = "GET";
     Request(url, method).then(json => {
-      const { data } = json.data;
-      const { allConfig } = data.allConfig;
-      this.setState({ allConfiguration: allConfig });
+      const data = json.data.configNotDefault;
+      this.setState({ allConfiguration: data });
+    });
+  }
+
+  handleUpDefault() {
+    const url = `${API_URL_GRAPHQL}?query=query{configDefault{id, name, number, time, temperature, timeBetweenCycles, upperLimit, inferiorLimit, upperTime, inferiorTime, disableShutdown, enableOutput}}`;
+
+    const method = "GET";
+
+    Request(url, method).then(response => {
+      const data = response.data.configDefault[0];
+
+      const configurationDefault = {
+        CONFIG_ENSAIO: {
+          LSL: data.inferiorLimit,
+          LWT: data.inferiorTime,
+          NOS: data.number,
+          TAO: data.enableOutput,
+          TAS: data.temperature,
+          TAT: data.time,
+          TBS: data.timeBetweenCycles,
+          TMO: data.disableShutdown,
+          USL: data.upperLimit,
+          UWT: data.upperTime
+        }
+      };
+
+      this.setState({ configuration: configurationDefault });
     });
   }
 
@@ -163,6 +190,13 @@ class Configuration extends React.Component {
 
         {selectConfiguration(this.handleChange, configStates, classes)}
         <ConfigurationForm configuration={configuration} />
+        <Button
+          onClick={this.handleUpDefault}
+          color="secondary"
+          variant="contained"
+        >
+          Padrão
+        </Button>
       </Grid>
     );
   }

--- a/unbrake-frontend/src/components/Configuration.jsx
+++ b/unbrake-frontend/src/components/Configuration.jsx
@@ -18,10 +18,19 @@ const query =
   "id, name, number, time, temperature, timeBetweenCycles, upperLimit, inferiorLimit, upperTime, inferiorTime, disableShutdown, enableOutput";
 
 export async function submit(configuration, name) {
-  const { TAS, TAT, TMO, TAO, UWT, NOS, LSL, USL, TBS, LWT } = configuration;
   if (name === "" || name === undefined) return;
 
-  const url = `${API_URL_GRAPHQL}?query=mutation{createConfig(name:"${name}",number:${NOS},timeBetweenCycles:${TBS},upperLimit:${USL},inferiorLimit:${LSL},upperTime:${UWT},inferiorTime:${LWT},disableShutdown:${TMO},enableOutput:${TAO},temperature:${TAS},time:${TAT}){config{number, timeBetweenCycles,upperLimit,inferiorLimit}}}`;
+  const url = `${API_URL_GRAPHQL}?query=mutation{createConfig(name:"${name}",number:${
+    configuration.NOS
+  },timeBetweenCycles:${configuration.TBS},upperLimit:${
+    configuration.USL
+  },inferiorLimit:${configuration.LSL},upperTime:${
+    configuration.UWT
+  },inferiorTime:${configuration.LWT},disableShutdown:${
+    configuration.TMO
+  },enableOutput:${configuration.TAO},temperature:${configuration.TAS},time:${
+    configuration.TAT
+  }){config{number, timeBetweenCycles,upperLimit,inferiorLimit}}}`;
   const method = "POST";
   await Request(url, method);
 
@@ -101,6 +110,24 @@ const dialogName = (handleChange, handleClose, dialogStates) => {
   );
 };
 
+const createConfig = data => {
+  const configurationDefault = {
+    CONFIG_ENSAIO: {
+      LSL: data.inferiorLimit,
+      LWT: data.inferiorTime,
+      NOS: data.number,
+      TAO: data.enableOutput,
+      TAS: data.temperature,
+      TAT: data.time,
+      TBS: data.timeBetweenCycles,
+      TMO: data.disableShutdown,
+      USL: data.upperLimit,
+      UWT: data.upperTime
+    }
+  };
+  return configurationDefault;
+};
+
 class Configuration extends React.Component {
   constructor(props) {
     super(props);
@@ -170,22 +197,7 @@ class Configuration extends React.Component {
       }
 
       const data = response.data.configDefault[0];
-
-      const configurationDefault = {
-        CONFIG_ENSAIO: {
-          LSL: data.inferiorLimit,
-          LWT: data.inferiorTime,
-          NOS: data.number,
-          TAO: data.enableOutput,
-          TAS: data.temperature,
-          TAT: data.time,
-          TBS: data.timeBetweenCycles,
-          TMO: data.disableShutdown,
-          USL: data.upperLimit,
-          UWT: data.upperTime
-        }
-      };
-
+      const configurationDefault = createConfig(data);
       this.setState({ configuration: configurationDefault });
     });
   }
@@ -208,21 +220,7 @@ class Configuration extends React.Component {
     Request(url, method).then(response => {
       const data = response.data.configAt;
 
-      const configurationDefault = {
-        CONFIG_ENSAIO: {
-          LSL: data.inferiorLimit,
-          LWT: data.inferiorTime,
-          NOS: data.number,
-          TAO: data.enableOutput,
-          TAS: data.temperature,
-          TAT: data.time,
-          TBS: data.timeBetweenCycles,
-          TMO: data.disableShutdown,
-          USL: data.upperLimit,
-          UWT: data.upperTime
-        }
-      };
-
+      const configurationDefault = createConfig(data);
       this.setState({ configuration: configurationDefault });
     });
   }

--- a/unbrake-frontend/src/components/Configuration.jsx
+++ b/unbrake-frontend/src/components/Configuration.jsx
@@ -4,6 +4,11 @@ import Input from "@material-ui/core/Input";
 import Grid from "@material-ui/core/Grid";
 import { withStyles } from "@material-ui/core/styles";
 import PropTypes from "prop-types";
+import OutlinedInput from "@material-ui/core/OutlinedInput";
+import InputLabel from "@material-ui/core/InputLabel";
+import MenuItem from "@material-ui/core/MenuItem";
+import FormControl from "@material-ui/core/FormControl";
+import Select from "@material-ui/core/Select";
 import ConfigurationForm from "./ConfigurationForm";
 
 const styles = () => ({
@@ -12,8 +17,39 @@ const styles = () => ({
   },
   grid: {
     padding: "5px"
+  },
+  formControl: {
+    minWidth: 200
   }
 });
+
+const selectConfiguration = (handleChange, dataBaseConfiguration, classes) => {
+  return (
+    <Grid item xs={4} className={classes.title}>
+      <FormControl variant="outlined" className={classes.formControl}>
+        <InputLabel htmlFor="outlined-age-simple">Configurações</InputLabel>
+        <Select
+          value={dataBaseConfiguration}
+          onChange={handleChange}
+          input={
+            <OutlinedInput
+              labelWidth={dataBaseConfiguration}
+              name="dataBaseConfiguration"
+              id="outlined-age-simple"
+            />
+          }
+        >
+          <MenuItem value={0}>
+            <em>None</em>
+          </MenuItem>
+          <MenuItem value={1}>Configuration 1</MenuItem>
+          <MenuItem value={2}>Configuration 2</MenuItem>
+          <MenuItem value={3}>Configuration 3</MenuItem>
+        </Select>
+      </FormControl>
+    </Grid>
+  );
+};
 
 class Configuration extends React.Component {
   constructor(props) {
@@ -33,10 +69,16 @@ class Configuration extends React.Component {
           USL: "",
           UWT: ""
         }
-      }
+      },
+      dataBaseConfiguration: 0
     };
 
+    this.handleChange = this.handleChange.bind(this);
     this.fileUpload = this.fileUpload.bind(this);
+  }
+
+  handleChange(event) {
+    this.setState({ [event.target.name]: event.target.value });
   }
 
   uploadField(field) {
@@ -85,18 +127,19 @@ class Configuration extends React.Component {
   }
 
   render() {
-    const { configuration } = this.state;
+    const { configuration, dataBaseConfiguration } = this.state;
+    const { classes } = this.props;
 
     return (
       <Grid
         alignItems="center"
         justify="center"
-        style={{ minHeight: "100vh" }}
+        style={{ minHeight: "5px" }}
         container
         spacing={40}
       >
-        {this.uploadField("calibration")}
         {this.uploadField("configuration")}
+        {selectConfiguration(this.handleChange, dataBaseConfiguration, classes)}
         <ConfigurationForm configuration={configuration} />
       </Grid>
     );

--- a/unbrake-frontend/src/components/Configuration.jsx
+++ b/unbrake-frontend/src/components/Configuration.jsx
@@ -10,6 +10,8 @@ import MenuItem from "@material-ui/core/MenuItem";
 import FormControl from "@material-ui/core/FormControl";
 import Select from "@material-ui/core/Select";
 import ConfigurationForm from "./ConfigurationForm";
+import { API_URL_GRAPHQL } from "../utils/Constants";
+import Request from "../utils/Request";
 
 const styles = () => ({
   title: {
@@ -22,6 +24,54 @@ const styles = () => ({
     minWidth: 200
   }
 });
+
+let allConfig = [{ id: 0, name: "" }];
+
+async function getConfigurationsId() {
+  const url = `${API_URL_GRAPHQL}?query=query{allConfig{id, name}}`;
+
+  const method = "POST";
+
+  const response = await Request(url, method);
+
+  allConfig = [{ id: 0, name: "" }];
+
+  allConfig = allConfig.concat(response.data.allConfig);
+  /*
+   * const one = 1;
+   * const zero = 0;
+   */
+
+  // let i;
+
+  /*
+   * for (i = zero; i < response.data.allConfig.length; i += one) {
+   *   allConfig[i + one] = response.data.allConfig[i];
+   *   // console.log(allConfig[i]);
+   * }
+   */
+
+  // console.log(allConfig.length);
+
+  // return response.data.allConfig;
+}
+
+const itensSelection = () => {
+  getConfigurationsId();
+  /*
+   * console.log("ConfigurationsTest", allConfig[0]);
+   * console.log(allConfig.length);
+   */
+
+  const itens = allConfig.map(value => {
+    return (
+      <MenuItem key={value.name + value.id} value={value.id}>
+        {value.name}
+      </MenuItem>
+    );
+  });
+  return itens;
+};
 
 const selectConfiguration = (handleChange, dataBaseConfiguration, classes) => {
   return (
@@ -39,12 +89,7 @@ const selectConfiguration = (handleChange, dataBaseConfiguration, classes) => {
             />
           }
         >
-          <MenuItem value={0}>
-            <em>None</em>
-          </MenuItem>
-          <MenuItem value={1}>Configuration 1</MenuItem>
-          <MenuItem value={2}>Configuration 2</MenuItem>
-          <MenuItem value={3}>Configuration 3</MenuItem>
+          {itensSelection()}
         </Select>
       </FormControl>
     </Grid>
@@ -114,13 +159,8 @@ class Configuration extends React.Component {
     reader.onload = e => {
       const content = e.target.result;
       const fileUpload = iniparser.parseString(content);
-      if (name === "configuration") {
-        scope.setState({ configuration: fileUpload });
-        scope.setState({ configuration: fileUpload });
-      }
-      if (name === "calibration") {
-        scope.setState({ calibration: fileUpload });
-      }
+      scope.setState({ configuration: fileUpload });
+      // console.log(fileUpload);
     };
 
     reader.readAsText(file, "UTF-8");
@@ -139,6 +179,7 @@ class Configuration extends React.Component {
         spacing={40}
       >
         {this.uploadField("configuration")}
+
         {selectConfiguration(this.handleChange, dataBaseConfiguration, classes)}
         <ConfigurationForm configuration={configuration} />
       </Grid>

--- a/unbrake-frontend/src/components/Configuration.jsx
+++ b/unbrake-frontend/src/components/Configuration.jsx
@@ -12,7 +12,7 @@ import DialogTitle from "@material-ui/core/DialogTitle";
 import Request from "../utils/Request";
 import { API_URL_GRAPHQL } from "../utils/Constants";
 import ConfigurationForm from "./ConfigurationForm";
-import styles from "./ConfigurationStyles";
+import styles from "./Styles";
 
 const query =
   "id, name, number, time, temperature, timeBetweenCycles, upperLimit, inferiorLimit, upperTime, inferiorTime, disableShutdown, enableOutput";
@@ -195,7 +195,6 @@ class Configuration extends React.Component {
       if (response.data.configDefault.length === VAZIO) {
         return;
       }
-
       const data = response.data.configDefault[0];
       const configurationDefault = createConfig(data);
       this.setState({ configuration: configurationDefault });

--- a/unbrake-frontend/src/components/Configuration.jsx
+++ b/unbrake-frontend/src/components/Configuration.jsx
@@ -1,17 +1,10 @@
 import React from "react";
 import iniparser from "iniparser";
-import Input from "@material-ui/core/Input";
-import Grid from "@material-ui/core/Grid";
+import { Input, Grid, Button, Dialog } from "@material-ui/core";
 import { withStyles } from "@material-ui/core/styles";
 import PropTypes from "prop-types";
-import OutlinedInput from "@material-ui/core/OutlinedInput";
-import InputLabel from "@material-ui/core/InputLabel";
 import MenuItem from "@material-ui/core/MenuItem";
-import FormControl from "@material-ui/core/FormControl";
-import Select from "@material-ui/core/Select";
-import Button from "@material-ui/core/Button";
 import TextField from "@material-ui/core/TextField";
-import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
@@ -19,18 +12,7 @@ import DialogTitle from "@material-ui/core/DialogTitle";
 import Request from "../utils/Request";
 import { API_URL_GRAPHQL } from "../utils/Constants";
 import ConfigurationForm from "./ConfigurationForm";
-
-const styles = () => ({
-  title: {
-    padding: "5px"
-  },
-  grid: {
-    padding: "5px"
-  },
-  formControl: {
-    minWidth: 200
-  }
-});
+import styles from "./ConfigurationStyles";
 
 const query =
   "id, name, number, time, temperature, timeBetweenCycles, upperLimit, inferiorLimit, upperTime, inferiorTime, disableShutdown, enableOutput";
@@ -63,22 +45,19 @@ const itensSelection = allConfiguration => {
 const selectConfiguration = (handleChange, configStates, classes) => {
   return (
     <Grid item xs={4} className={classes.title}>
-      <FormControl variant="outlined" className={classes.formControl}>
-        <InputLabel htmlFor="outlined-age-simple">Configurações</InputLabel>
-        <Select
-          value={configStates[0]}
-          onChange={handleChange}
-          input={
-            <OutlinedInput
-              labelWidth={configStates[0]}
-              name="dataBaseConfiguration"
-              id="outlined-age-simple"
-            />
-          }
-        >
-          {itensSelection(configStates[1])}
-        </Select>
-      </FormControl>
+      <TextField
+        id="outlined-select-currency"
+        select
+        label="Configurações"
+        value={configStates[0]}
+        onChange={handleChange}
+        name="dataBaseConfiguration"
+        className={classes.formControl}
+        margin="normal"
+        variant="outlined"
+      >
+        {itensSelection(configStates[1])}
+      </TextField>
     </Grid>
   );
 };
@@ -214,7 +193,6 @@ class Configuration extends React.Component {
   handleChange(event) {
     this.setState({ [event.target.name]: event.target.value });
     const invalidId = 0;
-
     if (
       event.target.name === "dataBaseConfiguration" &&
       event.target.value > invalidId
@@ -260,7 +238,7 @@ class Configuration extends React.Component {
     return (
       <Grid container item xs={10} alignItems="center" justify="center">
         <Grid item xs={4} className={classes.title}>
-          <h2 justify="left">Upload arquivo de {archive}</h2>
+          <h2>Upload arquivo de {archive}</h2>
         </Grid>
         <Grid item xs={4} className={classes.grid}>
           <Input
@@ -305,27 +283,34 @@ class Configuration extends React.Component {
     };
 
     return (
-      <Grid
-        alignItems="center"
-        justify="center"
-        style={{ minHeight: "5px" }}
-        container
-        spacing={40}
-      >
-        {this.uploadField("configuration")}
-
-        {selectConfiguration(this.handleChange, configStates, classes)}
-        <ConfigurationForm
-          configuration={configuration}
-          handleClickSave={this.handleClickSave}
-        />
-        <Button
-          onClick={this.handleUpDefault}
-          color="secondary"
-          variant="contained"
-        >
-          Padrão
-        </Button>
+      <Grid alignItems="center" container className={classes.configuration}>
+        <div>
+          <Grid container item justify="center">
+            {this.uploadField("configuration")}
+          </Grid>
+          <Grid container justify="center" item alignItems="center" xs={12}>
+            {selectConfiguration(this.handleChange, configStates, classes)}
+            <Button
+              onClick={this.handleUpDefault}
+              color="secondary"
+              variant="contained"
+            >
+              Configuração Padrão
+            </Button>
+          </Grid>
+          <Grid
+            container
+            alignItems="center"
+            xs={12}
+            item
+            className={classes.form}
+          >
+            <ConfigurationForm
+              configuration={configuration}
+              handleClickSave={this.handleClickSave}
+            />
+          </Grid>
+        </div>
         {dialogName(this.handleChange, this.handleClose, dialogStates)}
       </Grid>
     );

--- a/unbrake-frontend/src/components/Configuration.jsx
+++ b/unbrake-frontend/src/components/Configuration.jsx
@@ -37,6 +37,7 @@ const query =
 
 async function submit(configuration, name) {
   const { TAS, TAT, TMO, TAO, UWT, NOS, LSL, USL, TBS, LWT } = configuration;
+  if (name === "" || name === undefined) return;
 
   const url = `${API_URL_GRAPHQL}?query=mutation{createConfig(name:"${name}",number:${NOS},timeBetweenCycles:${TBS},upperLimit:${USL},inferiorLimit:${LSL},upperTime:${UWT},inferiorTime:${LWT},disableShutdown:${TMO},enableOutput:${TAO},temperature:${TAS},time:${TAT}){config{number, timeBetweenCycles,upperLimit,inferiorLimit}}}`;
   const method = "POST";
@@ -166,16 +167,6 @@ class Configuration extends React.Component {
     const CONFIG_ENSAIO = state.configuration;
     const newConfig = { CONFIG_ENSAIO };
     this.setState({ configuration: newConfig });
-
-    /*
-     * if (newConfig.CONFIG_ENSAIO.TAO === false) {
-     *   this.state.configuration.CONFIG_ENSAIO.TAO = false;
-     * }
-     * if (newConfig.CONFIG_ENSAIO.TMO === false) {
-     *   this.state.configuration.CONFIG_ENSAIO.TMO = false;
-     * }
-     */
-
     this.handleClickOpen();
   }
 
@@ -222,8 +213,12 @@ class Configuration extends React.Component {
 
   handleChange(event) {
     this.setState({ [event.target.name]: event.target.value });
+    const invalidId = 0;
 
-    if (event.target.name === "dataBaseConfiguration")
+    if (
+      event.target.name === "dataBaseConfiguration" &&
+      event.target.value > invalidId
+    )
       this.handleSelectConfig(event.target.value);
   }
 

--- a/unbrake-frontend/src/components/Configuration.jsx
+++ b/unbrake-frontend/src/components/Configuration.jsx
@@ -192,7 +192,13 @@ class Configuration extends React.Component {
 
     const method = "GET";
 
+    const VAZIO = 0;
+
     Request(url, method).then(response => {
+      if (response.data.configDefault.length === VAZIO) {
+        return;
+      }
+
       const data = response.data.configDefault[0];
 
       const configurationDefault = {

--- a/unbrake-frontend/src/components/ConfigurationForm.jsx
+++ b/unbrake-frontend/src/components/ConfigurationForm.jsx
@@ -239,9 +239,9 @@ class ConfigurationForm extends React.Component {
   }
 
   handleChange(event) {
-    const { target, name } = event;
+    const { target } = event;
     const value = target.type === "checkbox" ? target.checked : target.value;
-    const configuration = { [name]: value };
+    const configuration = { [event.target.name]: value };
     this.setState(prevState => ({
       configuration: { ...prevState.configuration, ...configuration }
     }));

--- a/unbrake-frontend/src/components/ConfigurationForm.jsx
+++ b/unbrake-frontend/src/components/ConfigurationForm.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { initialize, Field, reduxForm } from "redux-form";
 import { TextField, Checkbox } from "redux-form-material-ui";
 import { withStyles, Button, FormControlLabel, Grid } from "@material-ui/core";
-import styles from "./ConfigurationStyles";
+import styles from "./Styles";
 
 const limits = (value, allValues) => {
   return parseInt(allValues.LSL, 10) >= parseInt(allValues.USL, 10)

--- a/unbrake-frontend/src/components/ConfigurationForm.jsx
+++ b/unbrake-frontend/src/components/ConfigurationForm.jsx
@@ -194,17 +194,10 @@ const otherField = (classes, vector, handleChange) => {
   return fields;
 };
 
-
-async function submit(values, params) {
-  const url = `${API_URL_GRAPHQL}?query=mutation{createConfig(number:${
-    params.NOS
-  },timeBetweenCycles:${params.TBS},upperLimit:${params.USL},inferiorLimit:${
-    params.LSL
-  },upperTime:${params.UWT},inferiorTime:${params.LWT},disableShutdown:${
-    params.TMO
-  },enableOutput:${params.TAO},temperature:${params.TAS},time:${
-    params.TAT
-  }){config{number, timeBetweenCycles,upperLimit,inferiorLimit}}}`;
+async function submit(values, state) {
+  const { configuration } = state;
+  const { TAS, TAT, TMO, TAO, UWT, NOS, LSL, USL, TBS, LWT } = configuration;
+  const url = `${API_URL_GRAPHQL}?query=mutation{createConfig(name:"teste4",number:${NOS},timeBetweenCycles:${TBS},upperLimit:${USL},inferiorLimit:${LSL},upperTime:${UWT},inferiorTime:${LWT},disableShutdown:${TMO},enableOutput:${TAO},temperature:${TAS},time:${TAT}){config{number, timeBetweenCycles,upperLimit,inferiorLimit}}}`;
 
   const method = "POST";
 

--- a/unbrake-frontend/src/components/ConfigurationForm.jsx
+++ b/unbrake-frontend/src/components/ConfigurationForm.jsx
@@ -194,7 +194,7 @@ const otherField = (classes, vector, handleChange) => {
   return fields;
 };
 
-<<<<<<< HEAD
+
 async function submit(values, params) {
   const url = `${API_URL_GRAPHQL}?query=mutation{createConfig(number:${
     params.NOS
@@ -205,16 +205,6 @@ async function submit(values, params) {
   },enableOutput:${params.TAO},temperature:${params.TAS},time:${
     params.TAT
   }){config{number, timeBetweenCycles,upperLimit,inferiorLimit}}}`;
-=======
-async function submit(values, state) {
-  const { configuration } = state;
-  const { TAS, TAT, TMO, TAO, UWT, NOS, LSL, USL, TBS, LWT } = configuration;
-  const url = `${API_URL_GRAPHQL}?query=mutation{createConfig(number:${NOS},'
-              'timeBetweenCycles:${TBS},upperLimit:${USL},inferiorLimit:${LSL},'
-              'upperTime:${UWT},inferiorTime:${LWT},disableShutdown:${TMO},'
-              'enableOutput:${TAO},temperature:${TAS},time:${TAT}){config{number,'
-              'timeBetweenCycles,upperLimit,inferiorLimit}}}`;
->>>>>>> Create resolve to get configuration default
 
   const method = "POST";
 

--- a/unbrake-frontend/src/components/ConfigurationForm.jsx
+++ b/unbrake-frontend/src/components/ConfigurationForm.jsx
@@ -197,12 +197,12 @@ const otherField = (classes, vector, handleChange) => {
 async function submit(values, state) {
   const { configuration } = state;
   const { TAS, TAT, TMO, TAO, UWT, NOS, LSL, USL, TBS, LWT } = configuration;
-  const url = `${API_URL_GRAPHQL}?query=mutation{createConfig(name:"teste4",number:${NOS},timeBetweenCycles:${TBS},upperLimit:${USL},inferiorLimit:${LSL},upperTime:${UWT},inferiorTime:${LWT},disableShutdown:${TMO},enableOutput:${TAO},temperature:${TAS},time:${TAT}){config{number, timeBetweenCycles,upperLimit,inferiorLimit}}}`;
 
+  const url = `${API_URL_GRAPHQL}?query=mutation{createConfig(name:"teste5",number:${NOS},timeBetweenCycles:${TBS},upperLimit:${USL},inferiorLimit:${LSL},upperTime:${UWT},inferiorTime:${LWT},disableShutdown:${TMO},enableOutput:${TAO},temperature:${TAS},time:${TAT}){config{number, timeBetweenCycles,upperLimit,inferiorLimit}}}`;
   const method = "POST";
-
   const response = await Request(url, method);
 
+  window.location.reload();
   return response;
 }
 

--- a/unbrake-frontend/src/components/ConfigurationForm.jsx
+++ b/unbrake-frontend/src/components/ConfigurationForm.jsx
@@ -104,7 +104,7 @@ const fieldsConfigurations = (classes, vector, handleChange) => {
   return rows;
 };
 
-const checkBox = (classes, type) => {
+const checkBox = (classes, type, handleChange) => {
   let label;
   switch (type.name) {
     case "TMO":
@@ -119,8 +119,13 @@ const checkBox = (classes, type) => {
   return (
     <Grid container item xs={3} className={classes.gridButton} justify="center">
       <FormControlLabel
+        name={type.name}
         control={
-          <Field component={Checkbox} name={type.name} value={type.value} />
+          <Field
+            component={Checkbox}
+            onClick={handleChange}
+            value={type.value}
+          />
         }
         label={label}
       />
@@ -184,12 +189,27 @@ const otherField = (classes, vector, handleChange) => {
         alignItems="center"
         justify="center"
       >
-        {checkBox(classes, value[0])}
+        {checkBox(classes, value[0], handleChange)}
         {CommunGrid(classes, value[1], handleChange)}
       </Grid>
     );
   });
   return fields;
+};
+
+const verifyCheckbox = (TMO, TAO) => {
+  const dictionary = { TAO: "", TMO: "" };
+  if (TMO === "FALSE" || TMO === false) {
+    dictionary.TMO = false;
+  } else {
+    dictionary.TMO = true;
+  }
+  if (TAO === "FALSE" || TAO === false) {
+    dictionary.TAO = false;
+  } else {
+    dictionary.TAO = true;
+  }
+  return dictionary;
 };
 
 class ConfigurationForm extends React.Component {
@@ -213,15 +233,33 @@ class ConfigurationForm extends React.Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    const { configuration } = this.props;
+    const { configuration, dispatch } = this.props;
     if (configuration !== nextProps.configuration) {
       const rightConfig = Object.assign({}, nextProps.configuration);
-      rightConfig.CONFIG_ENSAIO.TMO =
-        nextProps.configuration.CONFIG_ENSAIO.TMO !== "FALSE";
-      rightConfig.CONFIG_ENSAIO.TAO =
-        nextProps.configuration.CONFIG_ENSAIO.TAO !== "FALSE";
-
-      const { dispatch } = this.props;
+      const next = verifyCheckbox(
+        nextProps.configuration.CONFIG_ENSAIO.TMO,
+        nextProps.configuration.CONFIG_ENSAIO.TAO
+      );
+      /*
+       * if (
+       *   nextProps.configuration.CONFIG_ENSAIO.TMO === "FALSE" ||
+       *   nextProps.configuration.CONFIG_ENSAIO.TMO === false
+       * ) {
+       *   rightConfig.CONFIG_ENSAIO.TMO = false;
+       * } else {
+       *   rightConfig.CONFIG_ENSAIO.TMO = true;
+       * }
+       * if (
+       *   nextProps.configuration.CONFIG_ENSAIO.TAO === "FALSE" ||
+       *   nextProps.configuration.CONFIG_ENSAIO.TAO === false
+       * ) {
+       *   rightConfig.CONFIG_ENSAIO.TAO = false;
+       * } else {
+       *   rightConfig.CONFIG_ENSAIO.TAO = true;
+       * }
+       */
+      rightConfig.CONFIG_ENSAIO.TMO = next.TMO;
+      rightConfig.CONFIG_ENSAIO.TAO = next.TAO;
       dispatch(initialize("configuration", rightConfig.CONFIG_ENSAIO));
       this.setState({ configuration: rightConfig.CONFIG_ENSAIO });
       return true;
@@ -230,9 +268,9 @@ class ConfigurationForm extends React.Component {
   }
 
   handleChange(event) {
-    const configuration = {};
-    const { name, value } = event.target;
-    configuration[name] = value;
+    const { target, name } = event;
+    const value = target.type === "checkbox" ? target.checked : target.value;
+    const configuration = { [name]: value };
     this.setState(prevState => ({
       configuration: { ...prevState.configuration, ...configuration }
     }));

--- a/unbrake-frontend/src/components/ConfigurationForm.jsx
+++ b/unbrake-frontend/src/components/ConfigurationForm.jsx
@@ -186,19 +186,14 @@ const Buttons = classes => {
   );
 };
 
-const verifyCheckbox = (TMO, TAO) => {
-  const dictionary = { TAO: "", TMO: "" };
-  if (TMO === "FALSE" || TMO === false) {
-    dictionary.TMO = false;
+const verifyCheckbox = variable => {
+  let bool;
+  if (variable === "FALSE" || variable === false) {
+    bool = false;
   } else {
-    dictionary.TMO = true;
+    bool = true;
   }
-  if (TAO === "FALSE" || TAO === false) {
-    dictionary.TAO = false;
-  } else {
-    dictionary.TAO = true;
-  }
-  return dictionary;
+  return bool;
 };
 
 class ConfigurationForm extends React.Component {
@@ -225,12 +220,9 @@ class ConfigurationForm extends React.Component {
     const { configuration, dispatch } = this.props;
     if (configuration !== nextProps.configuration) {
       const rightConfig = Object.assign({}, nextProps.configuration);
-      const next = verifyCheckbox(
-        nextProps.configuration.CONFIG_ENSAIO.TMO,
-        nextProps.configuration.CONFIG_ENSAIO.TAO
-      );
-      rightConfig.CONFIG_ENSAIO.TMO = next.TMO;
-      rightConfig.CONFIG_ENSAIO.TAO = next.TAO;
+      const next = nextProps.configuration.CONFIG_ENSAIO;
+      rightConfig.CONFIG_ENSAIO.TMO = verifyCheckbox(next.TMO);
+      rightConfig.CONFIG_ENSAIO.TAO = verifyCheckbox(next.TAO);
       dispatch(initialize("configuration", rightConfig.CONFIG_ENSAIO));
       this.setState({ configuration: rightConfig.CONFIG_ENSAIO });
       return true;

--- a/unbrake-frontend/src/components/ConfigurationForm.jsx
+++ b/unbrake-frontend/src/components/ConfigurationForm.jsx
@@ -194,6 +194,7 @@ const otherField = (classes, vector, handleChange) => {
   return fields;
 };
 
+<<<<<<< HEAD
 async function submit(values, params) {
   const url = `${API_URL_GRAPHQL}?query=mutation{createConfig(number:${
     params.NOS
@@ -204,6 +205,16 @@ async function submit(values, params) {
   },enableOutput:${params.TAO},temperature:${params.TAS},time:${
     params.TAT
   }){config{number, timeBetweenCycles,upperLimit,inferiorLimit}}}`;
+=======
+async function submit(values, state) {
+  const { configuration } = state;
+  const { TAS, TAT, TMO, TAO, UWT, NOS, LSL, USL, TBS, LWT } = configuration;
+  const url = `${API_URL_GRAPHQL}?query=mutation{createConfig(number:${NOS},'
+              'timeBetweenCycles:${TBS},upperLimit:${USL},inferiorLimit:${LSL},'
+              'upperTime:${UWT},inferiorTime:${LWT},disableShutdown:${TMO},'
+              'enableOutput:${TAO},temperature:${TAS},time:${TAT}){config{number,'
+              'timeBetweenCycles,upperLimit,inferiorLimit}}}`;
+>>>>>>> Create resolve to get configuration default
 
   const method = "POST";
 

--- a/unbrake-frontend/src/components/ConfigurationForm.jsx
+++ b/unbrake-frontend/src/components/ConfigurationForm.jsx
@@ -31,8 +31,6 @@ const validate = values => {
   return errors;
 };
 
-let nameField;
-
 const fieldsLabels = {
   NOS: "Numero de Snubs",
   USL: "Limite Superior (km/h)",
@@ -43,6 +41,7 @@ const fieldsLabels = {
 };
 
 const rowsFields = (classes, vector, handleChange) => {
+  let nameField;
   const fields = vector.map(value => {
     switch (value.name) {
       case "NOS":
@@ -67,19 +66,21 @@ const rowsFields = (classes, vector, handleChange) => {
         break;
     }
     return (
-      <Grid key={`row${nameField}`} item xs={3} className={classes.grid}>
-        <Field
-          id={nameField}
-          component={TextField}
-          label={fieldsLabels[nameField]}
-          onChange={handleChange}
-          type="number"
-          name={nameField}
-          validate={nameField === "USL" || nameField === "LSL" ? limits : []}
-          className={classes.textField}
-          margin="normal"
-          variant="outlined"
-        />
+      <Grid key={`row${nameField}`} container xs={3} item justify="center">
+        <div>
+          <Field
+            id={nameField}
+            component={TextField}
+            label={fieldsLabels[nameField]}
+            onChange={handleChange}
+            type="number"
+            name={nameField}
+            validate={nameField === "USL" || nameField === "LSL" ? limits : []}
+            className={classes.textField}
+            margin="normal"
+            variant="outlined"
+          />
+        </div>
       </Grid>
     );
   });
@@ -89,14 +90,7 @@ const rowsFields = (classes, vector, handleChange) => {
 const fieldsConfigurations = (classes, vector, handleChange) => {
   const rows = vector.map(value => {
     return (
-      <Grid
-        key={`field${value[0].name}`}
-        alignItems="center"
-        justify="center"
-        container
-        item
-        xs={12}
-      >
+      <Grid key={`${value[0].name}`} container xs={12} justify="center" item>
         {rowsFields(classes, value, handleChange)}
       </Grid>
     );
@@ -117,7 +111,7 @@ const checkBox = (classes, type, handleChange) => {
       break;
   }
   return (
-    <Grid container item xs={3} className={classes.gridButton} justify="center">
+    <Grid container item xs={3} style={{ paddingLeft: 20 }}>
       <FormControlLabel
         name={type.name}
         control={
@@ -129,21 +123,6 @@ const checkBox = (classes, type, handleChange) => {
         }
         label={label}
       />
-    </Grid>
-  );
-};
-
-const Buttons = (classes, submitting) => {
-  return (
-    <Grid container item xs={3} className={classes.grid}>
-      <Button
-        type="submit"
-        color="secondary"
-        variant="contained"
-        disabled={submitting}
-      >
-        Cadastrar
-      </Button>
     </Grid>
   );
 };
@@ -161,7 +140,7 @@ const CommunGrid = (classes, type, handleChange) => {
       break;
   }
   return (
-    <Grid item xs={6} className={classes.grid}>
+    <Grid item container xs={3} className={classes.grid} justify="center">
       <Field
         id={type.name}
         component={TextField}
@@ -186,15 +165,25 @@ const otherField = (classes, vector, handleChange) => {
         container
         item
         xs={12}
-        alignItems="center"
         justify="center"
       >
         {checkBox(classes, value[0], handleChange)}
         {CommunGrid(classes, value[1], handleChange)}
+        <Grid item container xs={3} />
       </Grid>
     );
   });
   return fields;
+};
+
+const Buttons = classes => {
+  return (
+    <Grid container item xs={3} className={classes.grid}>
+      <Button type="submit" color="secondary" variant="contained">
+        Cadastrar
+      </Button>
+    </Grid>
+  );
 };
 
 const verifyCheckbox = (TMO, TAO) => {
@@ -240,24 +229,6 @@ class ConfigurationForm extends React.Component {
         nextProps.configuration.CONFIG_ENSAIO.TMO,
         nextProps.configuration.CONFIG_ENSAIO.TAO
       );
-      /*
-       * if (
-       *   nextProps.configuration.CONFIG_ENSAIO.TMO === "FALSE" ||
-       *   nextProps.configuration.CONFIG_ENSAIO.TMO === false
-       * ) {
-       *   rightConfig.CONFIG_ENSAIO.TMO = false;
-       * } else {
-       *   rightConfig.CONFIG_ENSAIO.TMO = true;
-       * }
-       * if (
-       *   nextProps.configuration.CONFIG_ENSAIO.TAO === "FALSE" ||
-       *   nextProps.configuration.CONFIG_ENSAIO.TAO === false
-       * ) {
-       *   rightConfig.CONFIG_ENSAIO.TAO = false;
-       * } else {
-       *   rightConfig.CONFIG_ENSAIO.TAO = true;
-       * }
-       */
       rightConfig.CONFIG_ENSAIO.TMO = next.TMO;
       rightConfig.CONFIG_ENSAIO.TAO = next.TAO;
       dispatch(initialize("configuration", rightConfig.CONFIG_ENSAIO));
@@ -277,7 +248,7 @@ class ConfigurationForm extends React.Component {
   }
 
   render() {
-    const { classes, handleSubmit, submitting, handleClickSave } = this.props;
+    const { classes, handleSubmit, handleClickSave } = this.props;
     const { configuration } = this.state;
     const { TAS, TAT, TMO, TAO, UWT, NOS, LSL, USL, TBS, LWT } = configuration;
     const rowOne = [
@@ -304,15 +275,22 @@ class ConfigurationForm extends React.Component {
     return (
       <form
         className={classes.container}
-        autoComplete="off"
-        onSubmit={handleSubmit(values => {
-          submit(values, configuration);
+        onSubmit={handleSubmit(() => {
+          handleClickSave(this.state);
         })}
       >
         {fieldsConfigurations(classes, rows, this.handleChange)}
         {otherField(classes, othersFields, this.handleChange)}
-        <Grid container item xs={12} alignItems="center" justify="center">
-          {Buttons(classes, submitting)}
+        <Grid container xs={12} item justify="center">
+          <Grid
+            item
+            container
+            xs={6}
+            justify="center"
+            className={classes.gridButton}
+          >
+            {Buttons(classes)}
+          </Grid>
         </Grid>
       </form>
     );
@@ -322,7 +300,6 @@ class ConfigurationForm extends React.Component {
 ConfigurationForm.propTypes = {
   classes: PropTypes.objectOf(PropTypes.string).isRequired,
   handleSubmit: PropTypes.func.isRequired,
-  submitting: PropTypes.bool.isRequired,
   configuration: PropTypes.oneOfType([PropTypes.object]).isRequired,
   dispatch: PropTypes.func.isRequired,
   handleClickSave: PropTypes.func.isRequired

--- a/unbrake-frontend/src/components/ConfigurationForm.jsx
+++ b/unbrake-frontend/src/components/ConfigurationForm.jsx
@@ -3,9 +3,7 @@ import PropTypes from "prop-types";
 import { initialize, Field, reduxForm } from "redux-form";
 import { TextField, Checkbox } from "redux-form-material-ui";
 import { withStyles, Button, FormControlLabel, Grid } from "@material-ui/core";
-import Request from "../utils/Request";
-import { API_URL_GRAPHQL } from "../utils/Constants";
-import styles from "./Styles";
+import styles from "./ConfigurationStyles";
 
 const limits = (value, allValues) => {
   return parseInt(allValues.LSL, 10) >= parseInt(allValues.USL, 10)
@@ -194,18 +192,6 @@ const otherField = (classes, vector, handleChange) => {
   return fields;
 };
 
-async function submit(values, state) {
-  const { configuration } = state;
-  const { TAS, TAT, TMO, TAO, UWT, NOS, LSL, USL, TBS, LWT } = configuration;
-
-  const url = `${API_URL_GRAPHQL}?query=mutation{createConfig(name:"teste5",number:${NOS},timeBetweenCycles:${TBS},upperLimit:${USL},inferiorLimit:${LSL},upperTime:${UWT},inferiorTime:${LWT},disableShutdown:${TMO},enableOutput:${TAO},temperature:${TAS},time:${TAT}){config{number, timeBetweenCycles,upperLimit,inferiorLimit}}}`;
-  const method = "POST";
-  const response = await Request(url, method);
-
-  window.location.reload();
-  return response;
-}
-
 class ConfigurationForm extends React.Component {
   constructor(props) {
     super(props);
@@ -253,7 +239,7 @@ class ConfigurationForm extends React.Component {
   }
 
   render() {
-    const { classes, handleSubmit, submitting } = this.props;
+    const { classes, handleSubmit, submitting, handleClickSave } = this.props;
     const { configuration } = this.state;
     const { TAS, TAT, TMO, TAO, UWT, NOS, LSL, USL, TBS, LWT } = configuration;
     const rowOne = [
@@ -300,12 +286,13 @@ ConfigurationForm.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
   submitting: PropTypes.bool.isRequired,
   configuration: PropTypes.oneOfType([PropTypes.object]).isRequired,
-  dispatch: PropTypes.func.isRequired
+  dispatch: PropTypes.func.isRequired,
+  handleClickSave: PropTypes.func.isRequired
 };
 
-const Configuration = reduxForm({
+const Configurationa = reduxForm({
   form: "configuration",
   validate
 })(ConfigurationForm);
 
-export default withStyles(styles)(Configuration);
+export default withStyles(styles)(Configurationa);

--- a/unbrake-frontend/src/components/Styles.jsx
+++ b/unbrake-frontend/src/components/Styles.jsx
@@ -14,10 +14,23 @@ const styles = theme => ({
     width: 200
   },
   grid: {
-    padding: "px"
+    padding: "0px"
   },
   gridButton: {
-    paddingLeft: theme.spacing.unit + theme.spacing.unit
+    padding: "15px"
+  },
+  title: {
+    padding: "5px"
+  },
+  formControl: {
+    margin: theme.spacing.unit,
+    minWidth: 200
+  },
+  form: {
+    padding: "30px"
+  },
+  configuration: {
+    minHeight: "100vh"
   }
 });
 

--- a/unbrake-frontend/src/components/Styles.jsx
+++ b/unbrake-frontend/src/components/Styles.jsx
@@ -14,7 +14,7 @@ const styles = theme => ({
     width: 200
   },
   grid: {
-    padding: "0px"
+    padding: "px"
   },
   gridButton: {
     padding: "15px"

--- a/unbrake-frontend/src/tests/Calibration/__snapshots__/Vibration.test.jsx.snap
+++ b/unbrake-frontend/src/tests/Calibration/__snapshots__/Vibration.test.jsx.snap
@@ -9,13 +9,11 @@ exports[`<Vibration /> render() renders the component 1`] = `
       "dense": "ReduxForm-dense-3",
       "form": "ReduxForm-form-9",
       "formControl": "ReduxForm-formControl-8",
-
       "grid": "ReduxForm-grid-5",
       "gridButton": "ReduxForm-gridButton-6",
       "menu": "ReduxForm-menu-4",
       "textField": "ReduxForm-textField-2",
       "title": "ReduxForm-title-7",
-
     }
   }
   destroyOnUnmount={true}

--- a/unbrake-frontend/src/tests/Calibration/__snapshots__/Vibration.test.jsx.snap
+++ b/unbrake-frontend/src/tests/Calibration/__snapshots__/Vibration.test.jsx.snap
@@ -4,12 +4,18 @@ exports[`<Vibration /> render() renders the component 1`] = `
 <Hoc
   classes={
     Object {
+      "configuration": "ReduxForm-configuration-10",
       "container": "ReduxForm-container-1",
       "dense": "ReduxForm-dense-3",
+      "form": "ReduxForm-form-9",
+      "formControl": "ReduxForm-formControl-8",
+
       "grid": "ReduxForm-grid-5",
       "gridButton": "ReduxForm-gridButton-6",
       "menu": "ReduxForm-menu-4",
       "textField": "ReduxForm-textField-2",
+      "title": "ReduxForm-title-7",
+
     }
   }
   destroyOnUnmount={true}

--- a/unbrake-frontend/src/tests/Configuration.test.jsx
+++ b/unbrake-frontend/src/tests/Configuration.test.jsx
@@ -1,12 +1,54 @@
 import React from "react";
 import Enzyme, { shallow } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
-import Configuration from "../components/Configuration";
+import fetch from "jest-fetch-mock";
+import Configuration, { submit } from "../components/Configuration";
 import ComponentTest from "./ComponentTest";
+import { API_URL_GRAPHQL } from "../utils/Constants";
 
 Enzyme.configure({ adapter: new Adapter() });
 
 describe("<Configuration />", () => {
   const wrapper = shallow(<Configuration />);
   ComponentTest(wrapper);
+
+  /*
+   * test("submit()", () => {
+   *   const url
+   */
+
+  // })
+});
+
+describe("submit", () => {
+  it("Call request and return response", () => {
+    beforeEach(() => {
+      fetch.resetMocks();
+    });
+    const configuration = {
+      LSL: 10,
+      LWT: 10,
+      NOS: 10,
+      TAO: false,
+      TAS: 10,
+      TAT: 10,
+      TBS: 10,
+      TMO: false,
+      USL: 10,
+      UWT: 10
+    };
+    const name = "test";
+    let response = "";
+    fetch.mockResponseOnce(
+      JSON.stringify({ data: { createConfig: { name } } })
+    );
+
+    submit(configuration, name)
+      .then(res => {
+        response = res.data.createConfig.name;
+        expect(response).toBe(name);
+        expect(fetch.mock.calls[0][0]).toEqual(API_URL_GRAPHQL);
+      })
+      .catch(() => {});
+  });
 });

--- a/unbrake-frontend/src/tests/Configuration.test.jsx
+++ b/unbrake-frontend/src/tests/Configuration.test.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import Enzyme, { shallow } from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
-import fetch from "jest-fetch-mock";
-import Configuration, { submit } from "../components/Configuration";
+// import fetch from "jest-fetch-mock";
+import Configuration from "../components/Configuration";
 import ComponentTest from "./ComponentTest";
-import { API_URL_GRAPHQL } from "../utils/Constants";
+// import { API_URL_GRAPHQL } from "../utils/Constants";
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -20,35 +20,39 @@ describe("<Configuration />", () => {
   // })
 });
 
-describe("submit", () => {
-  it("Call request and return response", () => {
-    beforeEach(() => {
-      fetch.resetMocks();
-    });
-    const configuration = {
-      LSL: 10,
-      LWT: 10,
-      NOS: 10,
-      TAO: false,
-      TAS: 10,
-      TAT: 10,
-      TBS: 10,
-      TMO: false,
-      USL: 10,
-      UWT: 10
-    };
-    const name = "test";
-    let response = "";
-    fetch.mockResponseOnce(
-      JSON.stringify({ data: { createConfig: { name } } })
-    );
+/*
+ * describe("submit", () => {
+ *   it("Call request and return response", () => {
+ *     beforeEach(() => {
+ *       fetch.resetMocks();
+ *     });
+ *     const configuration = {
+ *       LSL: 10,
+ *       LWT: 10,
+ *       NOS: 10,
+ *       TAO: false,
+ *       TAS: 10,
+ *       TAT: 10,
+ *       TBS: 10,
+ *       TMO: false,
+ *       USL: 10,
+ *       UWT: 10
+ *     };
+ *     const name = "test";
+ *     let response = "";
+ *     fetch.mockResponseOnce(
+ *       JSON.stringify({ data: { createConfig: { name } } })
+ *     );
+ */
 
-    submit(configuration, name)
-      .then(res => {
-        response = res.data.createConfig.name;
-        expect(response).toBe(name);
-        expect(fetch.mock.calls[0][0]).toEqual(API_URL_GRAPHQL);
-      })
-      .catch(() => {});
-  });
-});
+/*
+ *     submit(configuration, name)
+ *       .then(res => {
+ *         response = res.data.createConfig.name;
+ *         expect(response).toBe(name);
+ *         expect(fetch.mock.calls[0][0]).toEqual(API_URL_GRAPHQL);
+ *       })
+ *       .catch(() => {});
+ *   });
+ * });
+ */

--- a/unbrake-frontend/src/tests/__snapshots__/Configuration.test.jsx.snap
+++ b/unbrake-frontend/src/tests/__snapshots__/Configuration.test.jsx.snap
@@ -3,108 +3,115 @@
 exports[`<Configuration /> render() renders the component 1`] = `
 <WithStyles(Grid)
   alignItems="center"
+  className="Configuration-configuration-10"
   container={true}
-  justify="center"
-  spacing={40}
-  style={
-    Object {
-      "minHeight": "5px",
-    }
-  }
 >
-  <WithStyles(Grid)
-    alignItems="center"
-    container={true}
-    item={true}
-    justify="center"
-    xs={10}
-  >
+  <div>
     <WithStyles(Grid)
-      className="Configuration-title-1"
+      container={true}
       item={true}
-      xs={4}
+      justify="center"
     >
-      <h2
-        justify="left"
+      <WithStyles(Grid)
+        alignItems="center"
+        container={true}
+        item={true}
+        justify="center"
+        xs={10}
       >
-        Upload arquivo de 
-        Configuração
-      </h2>
+        <WithStyles(Grid)
+          className="Configuration-title-7"
+          item={true}
+          xs={4}
+        >
+          <h2>
+            Upload arquivo de 
+            Configuração
+          </h2>
+        </WithStyles(Grid)>
+        <WithStyles(Grid)
+          className="Configuration-grid-5"
+          item={true}
+          xs={4}
+        >
+          <WithStyles(Input)
+            name="configuration"
+            onChange={[Function]}
+            type="file"
+          />
+        </WithStyles(Grid)>
+      </WithStyles(Grid)>
     </WithStyles(Grid)>
     <WithStyles(Grid)
-      className="Configuration-grid-2"
+      alignItems="center"
+      container={true}
       item={true}
-      xs={4}
+      justify="center"
+      xs={12}
     >
-      <WithStyles(Input)
-        name="configuration"
-        onChange={[Function]}
-        type="file"
+      <WithStyles(Grid)
+        className="Configuration-title-7"
+        item={true}
+        xs={4}
+      >
+        <TextField
+          className="Configuration-formControl-8"
+          id="outlined-select-currency"
+          label="Configurações"
+          margin="normal"
+          name="dataBaseConfiguration"
+          onChange={[Function]}
+          required={false}
+          select={true}
+          value={0}
+          variant="outlined"
+        >
+          <WithStyles(MenuItem)
+            key="0"
+            value={0}
+          />
+          <WithStyles(MenuItem)
+            key="NaN"
+          />
+        </TextField>
+      </WithStyles(Grid)>
+      <WithStyles(Button)
+        color="secondary"
+        onClick={[Function]}
+        variant="contained"
+      >
+        Configuração Padrão
+      </WithStyles(Button)>
+    </WithStyles(Grid)>
+    <WithStyles(Grid)
+      alignItems="center"
+      className="Configuration-form-9"
+      container={true}
+      item={true}
+      xs={12}
+    >
+      <WithStyles(ReduxForm)
+        configuration={
+          Object {
+            "CONFIG_ENSAIO": Object {
+              "LSL": "",
+              "LWT": "",
+              "NOS": "",
+              "TAO": false,
+              "TAS": "",
+              "TAT": "",
+              "TBS": "",
+              "TMO": false,
+              "USL": "",
+              "UWT": "",
+            },
+            "name": "",
+          }
+        }
+        handleClickSave={[Function]}
       />
     </WithStyles(Grid)>
-  </WithStyles(Grid)>
-  <WithStyles(Grid)
-    className="Configuration-title-1"
-    item={true}
-    xs={4}
-  >
-    <WithStyles(FormControl)
-      className="Configuration-formControl-3"
-      variant="outlined"
-    >
-      <WithStyles(WithFormControlContext(InputLabel))
-        htmlFor="outlined-age-simple"
-      >
-        Configurações
-      </WithStyles(WithFormControlContext(InputLabel))>
-      <WithStyles(WithFormControlContext(Select))
-        input={
-          <WithStyles(OutlinedInput)
-            id="outlined-age-simple"
-            labelWidth={0}
-            name="dataBaseConfiguration"
-          />
-        }
-        onChange={[Function]}
-        value={0}
-      >
-        <WithStyles(MenuItem)
-          key="0"
-          value={0}
-        />
-        <WithStyles(MenuItem)
-          key="NaN"
-        />
-      </WithStyles(WithFormControlContext(Select))>
-    </WithStyles(FormControl)>
-  </WithStyles(Grid)>
-  <WithStyles(ReduxForm)
-    configuration={
-      Object {
-        "CONFIG_ENSAIO": Object {
-          "LSL": "",
-          "LWT": "",
-          "NOS": "",
-          "TAO": false,
-          "TAS": "",
-          "TAT": "",
-          "TBS": "",
-          "TMO": false,
-          "USL": "",
-          "UWT": "",
-        },
-        "name": "",
-      }
-    }
-    handleClickSave={[Function]}
-  />
-  <WithStyles(Button)
-    color="secondary"
-    onClick={[Function]}
-    variant="contained"
-  >
-    Padrão
-  </WithStyles(Button)>
+  </div>
   <WithStyles(Dialog)
     aria-labelledby="form-dialog-title"
     onClose={[Function]}

--- a/unbrake-frontend/src/tests/__snapshots__/Configuration.test.jsx.snap
+++ b/unbrake-frontend/src/tests/__snapshots__/Configuration.test.jsx.snap
@@ -93,8 +93,10 @@ exports[`<Configuration /> render() renders the component 1`] = `
           "USL": "",
           "UWT": "",
         },
+        "name": "",
       }
     }
+    handleClickSave={[Function]}
   />
   <WithStyles(Button)
     color="secondary"
@@ -103,5 +105,47 @@ exports[`<Configuration /> render() renders the component 1`] = `
   >
     Padrão
   </WithStyles(Button)>
+  <WithStyles(Dialog)
+    aria-labelledby="form-dialog-title"
+    onClose={[Function]}
+    open={false}
+  >
+    <WithStyles(DialogTitle)
+      id="form-dialog-title"
+    >
+      Nome da Configuração
+    </WithStyles(DialogTitle)>
+    <WithStyles(DialogContent)>
+      <WithStyles(DialogContentText)>
+        Insira aqui o nome que você deseja dar para este arquivo de configuração
+      </WithStyles(DialogContentText)>
+      <TextField
+        autoFocus={true}
+        fullWidth={true}
+        label="Nome"
+        margin="dense"
+        name="name"
+        onChange={[Function]}
+        required={false}
+        select={false}
+        type="text"
+        variant="standard"
+      />
+    </WithStyles(DialogContent)>
+    <WithStyles(DialogActions)>
+      <WithStyles(Button)
+        color="primary"
+        onClick={[Function]}
+      >
+        Cancelar
+      </WithStyles(Button)>
+      <WithStyles(Button)
+        color="primary"
+        onClick={[Function]}
+      >
+        Cadastrar
+      </WithStyles(Button)>
+    </WithStyles(DialogActions)>
+  </WithStyles(Dialog)>
 </WithStyles(Grid)>
 `;

--- a/unbrake-frontend/src/tests/__snapshots__/Configuration.test.jsx.snap
+++ b/unbrake-frontend/src/tests/__snapshots__/Configuration.test.jsx.snap
@@ -69,27 +69,9 @@ exports[`<Configuration /> render() renders the component 1`] = `
         value={0}
       >
         <WithStyles(MenuItem)
+          key="0"
           value={0}
-        >
-          <em>
-            None
-          </em>
-        </WithStyles(MenuItem)>
-        <WithStyles(MenuItem)
-          value={1}
-        >
-          Configuration 1
-        </WithStyles(MenuItem)>
-        <WithStyles(MenuItem)
-          value={2}
-        >
-          Configuration 2
-        </WithStyles(MenuItem)>
-        <WithStyles(MenuItem)
-          value={3}
-        >
-          Configuration 3
-        </WithStyles(MenuItem)>
+        />
       </WithStyles(WithFormControlContext(Select))>
     </WithStyles(FormControl)>
   </WithStyles(Grid)>

--- a/unbrake-frontend/src/tests/__snapshots__/Configuration.test.jsx.snap
+++ b/unbrake-frontend/src/tests/__snapshots__/Configuration.test.jsx.snap
@@ -72,6 +72,9 @@ exports[`<Configuration /> render() renders the component 1`] = `
           key="0"
           value={0}
         />
+        <WithStyles(MenuItem)
+          key="NaN"
+        />
       </WithStyles(WithFormControlContext(Select))>
     </WithStyles(FormControl)>
   </WithStyles(Grid)>

--- a/unbrake-frontend/src/tests/__snapshots__/Configuration.test.jsx.snap
+++ b/unbrake-frontend/src/tests/__snapshots__/Configuration.test.jsx.snap
@@ -82,7 +82,6 @@ exports[`<Configuration /> render() renders the component 1`] = `
           "LSL": "",
           "LWT": "",
           "NOS": "",
-          "PTD": "",
           "TAO": false,
           "TAS": "",
           "TAT": "",
@@ -94,5 +93,12 @@ exports[`<Configuration /> render() renders the component 1`] = `
       }
     }
   />
+  <WithStyles(Button)
+    color="secondary"
+    onClick={[Function]}
+    variant="contained"
+  >
+    Padrão
+  </WithStyles(Button)>
 </WithStyles(Grid)>
 `;

--- a/unbrake-frontend/src/tests/__snapshots__/Configuration.test.jsx.snap
+++ b/unbrake-frontend/src/tests/__snapshots__/Configuration.test.jsx.snap
@@ -8,41 +8,10 @@ exports[`<Configuration /> render() renders the component 1`] = `
   spacing={40}
   style={
     Object {
-      "minHeight": "100vh",
+      "minHeight": "5px",
     }
   }
 >
-  <WithStyles(Grid)
-    alignItems="center"
-    container={true}
-    item={true}
-    justify="center"
-    xs={10}
-  >
-    <WithStyles(Grid)
-      className="Configuration-title-1"
-      item={true}
-      xs={4}
-    >
-      <h2
-        justify="left"
-      >
-        Upload arquivo de 
-        Calibração
-      </h2>
-    </WithStyles(Grid)>
-    <WithStyles(Grid)
-      className="Configuration-grid-2"
-      item={true}
-      xs={4}
-    >
-      <WithStyles(Input)
-        name="calibration"
-        onChange={[Function]}
-        type="file"
-      />
-    </WithStyles(Grid)>
-  </WithStyles(Grid)>
   <WithStyles(Grid)
     alignItems="center"
     container={true}
@@ -73,6 +42,56 @@ exports[`<Configuration /> render() renders the component 1`] = `
         type="file"
       />
     </WithStyles(Grid)>
+  </WithStyles(Grid)>
+  <WithStyles(Grid)
+    className="Configuration-title-1"
+    item={true}
+    xs={4}
+  >
+    <WithStyles(FormControl)
+      className="Configuration-formControl-3"
+      variant="outlined"
+    >
+      <WithStyles(WithFormControlContext(InputLabel))
+        htmlFor="outlined-age-simple"
+      >
+        Configurações
+      </WithStyles(WithFormControlContext(InputLabel))>
+      <WithStyles(WithFormControlContext(Select))
+        input={
+          <WithStyles(OutlinedInput)
+            id="outlined-age-simple"
+            labelWidth={0}
+            name="dataBaseConfiguration"
+          />
+        }
+        onChange={[Function]}
+        value={0}
+      >
+        <WithStyles(MenuItem)
+          value={0}
+        >
+          <em>
+            None
+          </em>
+        </WithStyles(MenuItem)>
+        <WithStyles(MenuItem)
+          value={1}
+        >
+          Configuration 1
+        </WithStyles(MenuItem)>
+        <WithStyles(MenuItem)
+          value={2}
+        >
+          Configuration 2
+        </WithStyles(MenuItem)>
+        <WithStyles(MenuItem)
+          value={3}
+        >
+          Configuration 3
+        </WithStyles(MenuItem)>
+      </WithStyles(WithFormControlContext(Select))>
+    </WithStyles(FormControl)>
   </WithStyles(Grid)>
   <WithStyles(ReduxForm)
     configuration={


### PR DESCRIPTION
# Selecionar configurações no banco de dados

## Problema/Funcionalidade

Selecionar configurações no banco de dados ou utilizar a configuração padrão definida pelo admin do sistema.
Agora também é necessário atribuir um nome a configuração que será salva

### Como foi implementado

- A seleção das configurações foi implementada através do Select presente no [Text Field](https://material-ui.com/demos/text-fields/) do material-ui;
- Para utilizar a configuração padrão basta o usuário pressionar o botão com esta descrição;
- A solicitação do nome da configuração que o usuário deseja selecionar é feita através do [Dialog](https://material-ui.com/demos/dialogs/) do material-ui.

### Possíveis melhorias

Incluir um feedback via poup up para o usuário informando o sucesso ou falha no cadastro das configurações, além de informar que ele não consegue cadastrar a configuração se o nome estiver em branco.

### Autores

@tmcstiago @medeiroslucas 

### Issue

resolves #165 