### PR TITLE
Adiciona proxy reverso para aproveitamento de porta

### DIFF
--- a/deploy/compose.base.yml
+++ b/deploy/compose.base.yml
@@ -3,6 +3,18 @@
 version: '3.7'
 
 services:
+  proxy:
+    image: 'nginx:1.15.12-alpine'
+    container_name: 'proxy'
+    volumes:
+      - "./logs/nginx_proxy:/var/log/nginx"
+    ports:
+      - "80:80"
+    depends_on:
+      - api_server
+      - frontend
+    restart: unless-stopped
+
   api:
     image: 'unbrake/api:latest'
     depends_on:
@@ -15,10 +27,8 @@ services:
   frontend:
     image: 'unbrake/frontend:latest'
     volumes:
-      - "./logs/nginx:/var/log/nginx_frontend"
+      - "./logs/nginx_frontend:/var/log/nginx"
     restart: unless-stopped
-    ports:
-      - "80:80"
 
   db:
     image: 'postgres:11.2-alpine'
@@ -39,9 +49,7 @@ services:
     image: 'nginx:1.15.12-alpine'
     container_name: 'api-server'
     volumes:
-      - "./logs/nginx:/var/log/nginx_api"
-    ports:
-      - "8080:80"
+      - "./logs/nginx_api:/var/log/nginx"
     depends_on:
       - api
     restart: unless-stopped
@@ -50,7 +58,7 @@ services:
     container_name: 'mqtt'
     image: 'emitter/server'
     ports:
-      - "1883:8080"
+      - "8080:8080"
     env_file:
       - .env_mqtt
     restart: unless-stopped

--- a/deploy/compose.prod.yml
+++ b/deploy/compose.prod.yml
@@ -3,6 +3,9 @@
 version: '3.7'
 
 services:
+  proxy:
+    volumes:
+      - "./nginx.proxy.prod.conf:/etc/nginx/nginx.conf"
   api:
     secrets:
       - api-django-secret-key
@@ -12,15 +15,12 @@ services:
     volumes:
       - "./frontend/nginx.prod.conf:/etc/nginx/nginx.conf"
       - "./https_certificate.crt:/etc/nginx/ssl/https_certificate.crt"
-    ports:
-      - "443:443"
     secrets:
       - https_key
 
   api_server:
     volumes:
       - "./api/nginx.prod.conf:/etc/nginx/nginx.conf"
-      - "./logs/nginx:/var/log/nginx_api"
 
 secrets:
   https_key:

--- a/deploy/compose.staging.yml
+++ b/deploy/compose.staging.yml
@@ -3,6 +3,9 @@
 version: '3.7'
 
 services:
+  proxy:
+    volumes:
+      - "./nginx.proxy.staging.conf:/etc/nginx/nginx.conf"
   api:
     image: 'unbrake/api:latest-staging'
 
@@ -14,4 +17,3 @@ services:
   api_server:
     volumes:
       - "./api/nginx.staging.conf:/etc/nginx/nginx.conf"
-      - "./logs/nginx:/var/log/nginx_api"

--- a/deploy/nginx.proxy.prod.conf
+++ b/deploy/nginx.proxy.prod.conf
@@ -1,0 +1,44 @@
+user nobody nogroup;
+
+error_log /var/log/nginx/error.log debug;
+pid /var/run/nginx.pid;
+
+events {
+  worker_connections 1024;
+  use epoll;
+}
+
+http {
+  upstream unbrake_frontend {
+    server frontend:80;
+  }
+
+  server {
+    server_name unbrake.ml www.unbrake.ml frontend.unbrake.ml www.frontend.unbrake.ml;
+    listen 80;
+
+    location / {
+      proxy_pass http://unbrake_frontend;
+
+      proxy_set_header  Host             $host;
+      proxy_set_header  X-Real-IP        $remote_addr;
+      proxy_set_header  X-Forwarded-For  $proxy_add_x_forwarded_for;
+    }
+  }
+
+  upstream unbrake_api {
+    server api-server:80;
+  }
+  server {
+    listen 80;
+    server_name api.unbrake.ml www.api.unbrake.ml;
+
+    location / {
+      proxy_pass http://unbrake_api/graphql;
+
+      proxy_set_header  Host             $host;
+      proxy_set_header  X-Real-IP        $remote_addr;
+      proxy_set_header  X-Forwarded-For  $proxy_add_x_forwarded_for;
+    }
+  }
+}

--- a/deploy/nginx.proxy.staging.conf
+++ b/deploy/nginx.proxy.staging.conf
@@ -1,0 +1,44 @@
+user nobody nogroup;
+
+error_log /var/log/nginx/error.log debug;
+pid /var/run/nginx.pid;
+
+events {
+  worker_connections 1024;
+  use epoll;
+}
+
+http {
+  upstream unbrake_frontend {
+    server frontend:80;
+  }
+
+  server {
+    server_name unbrake-hom.ml www.unbrake-hom.ml frontend.unbrake-hom.ml www.frontend.unbrake-hom.ml;
+    listen 80;
+
+    location / {
+      proxy_pass http://unbrake_frontend;
+
+      proxy_set_header  Host             $host;
+      proxy_set_header  X-Real-IP        $remote_addr;
+      proxy_set_header  X-Forwarded-For  $proxy_add_x_forwarded_for;
+    }
+  }
+
+  upstream unbrake_api {
+    server api-server:80;
+  }
+  server {
+    listen 80;
+    server_name api.unbrake-hom.ml www.api.unbrake-hom.ml;
+
+    location / {
+      proxy_pass http://unbrake_api/graphql;
+
+      proxy_set_header  Host             $host;
+      proxy_set_header  X-Real-IP        $remote_addr;
+      proxy_set_header  X-Forwarded-For  $proxy_add_x_forwarded_for;
+    }
+  }
+}

--- a/deploy/scripts/deploy
+++ b/deploy/scripts/deploy
@@ -27,6 +27,7 @@ copy_module_files
 echo -e "Copying secrets to ${REMOTE_HOST}..."
 scp -r secrets api frontend root@${REMOTE_HOST}:/root/
 scp -r compose.* root@${REMOTE_HOST}:/root/
+scp -r nginx.* root@${REMOTE_HOST}:/root/
 scp .env* root@${REMOTE_HOST}:/root/
 
 echo -e "\nDeploying to ${REMOTE_HOST}..."

--- a/unbrake-frontend/.env.development
+++ b/unbrake-frontend/.env.development
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=http://localhost:8080
+REACT_APP_API_URL=http://localhost:8080/graphql

--- a/unbrake-frontend/.env.production
+++ b/unbrake-frontend/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_API_URL="http://unbrake.ml:8080"
+REACT_APP_API_URL="api.unbrake-hom.ml"

--- a/unbrake-frontend/.env.staging
+++ b/unbrake-frontend/.env.staging
@@ -1,1 +1,1 @@
-REACT_APP_API_URL="http://unbrake-hom.ml:8080"
+REACT_APP_API_URL="api.unbrake-hom.ml"

--- a/unbrake-frontend/src/utils/Constants.jsx
+++ b/unbrake-frontend/src/utils/Constants.jsx
@@ -1,2 +1,2 @@
 export const API_URL = process.env.REACT_APP_API_URL;
-export const API_URL_GRAPHQL = `${API_URL}/graphql`;
+export const API_URL_GRAPHQL = process.env.REACT_APP_API_URL;


### PR DESCRIPTION
## O que faz?

Agora o frontend e api serão servidos na mesma porta. A API estará acessível através da url api.unbrake-hom.ml para homologação e api.unbrake.ml (quando merjado para a master) para produção.

Com isso, a porta 8080 não servirá mais a API e será usada para a comunicação MQTT, tornando a aplicação unbrake viável na rede da universidade.

## Como validar?

Além de olhar o código vai ser meio complicado, porque os efeitos serão sentidos após o merge.

## Issues
Closes #226 